### PR TITLE
Python objects for easy import and manipulation.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Grant Hulegaard <loki.labrys@gmail.com> `@gshulegaard <https://github.com/gshulegaard> <https://gitlab.com/gshulegaard>`_

--- a/README.rst
+++ b/README.rst
@@ -593,7 +593,7 @@ Tips
 
 To run a subset of tests::
 
-    tox -e <env> -- py.test <test>
+    tox -e <env> -- <path/to/test::test_name>
 
 To run all the test environments in *parallel* (you need to ``pip install detox``)::
 

--- a/README.rst
+++ b/README.rst
@@ -593,7 +593,7 @@ Tips
 
 To run a subset of tests::
 
-    tox -e <env> -- <path/to/test::test_name>
+    tox -e <env> -- tests/<file>[::test]
 
 To run all the test environments in *parallel* (you need to ``pip install detox``)::
 

--- a/crossplane/__init__.py
+++ b/crossplane/__init__.py
@@ -2,9 +2,9 @@
 from .parser import parse
 from .lexer import lex
 from .builder import build
-from .objects import xmap, ximport
+from .objects import map, load
 
-__all__ = ['parse', 'lex', 'build', 'xmap', 'ximport']
+__all__ = ['parse', 'lex', 'build', 'map', 'load']
 
 __title__ = 'crossplane'
 __summary__ = 'Reliable and fast NGINX configuration file parser.'

--- a/crossplane/__init__.py
+++ b/crossplane/__init__.py
@@ -2,8 +2,9 @@
 from .parser import parse
 from .lexer import lex
 from .builder import build
+from .objects import xmap, ximport
 
-__all__ = ['parse', 'lex', 'build']
+__all__ = ['parse', 'lex', 'build', 'xmap', 'ximport']
 
 __title__ = 'crossplane'
 __summary__ = 'Reliable and fast NGINX configuration file parser.'

--- a/crossplane/objects.py
+++ b/crossplane/objects.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+from .parser import parse
+
+
+#
+# Functions
+#
+
+def _init_directive(directive_json):
+    return NGXBlockDirective(**directive_json) if 'block' in directive_json \
+        else NGXDirective(**directive_json)
+
+
+#
+# Classes
+#
+
+class NGXDirective(object):
+    __slots__ = ('directive', 'line', 'args', 'includes')
+
+    def __init__(self, directive='', line=0, args=[], includes=[], **kwargs):
+        self.directive = directive
+        self.line = line
+        self.args = args
+        self.includes = []
+
+    def dict(self):
+        return {
+            slot: getattr(self, slot)
+            for slot in self.__slots__
+        }
+
+
+class NGXBlockDirective(NGXDirective):
+    __slots__ = ('index', 'directive', 'line', 'args', 'block')
+
+    def __init__(self, block=[], **kwargs):
+        super(NGXBlockDirective, self).__init__(**kwargs)
+        self.index = {}
+        self.block = block
+
+        self._setup_block()
+
+    def _setup_block(self):
+        directives = []
+        for directive_json in self.block:
+            directives.append(_init_directive(directive_json))
+            self.__index(directives[-1])
+
+        self.block = directives
+
+    def __index(self, directive):
+        idx = self.index.get(directive.directive, [])
+        idx.append(directive)
+        self.index[directive.directive] = idx
+
+    def __contains__(self, item):
+        return item in self.index
+
+    def __getattr__(self, name):
+        if name in self.index:
+            return self.get(name)
+        else:
+            raise AttributeError(
+                '"{0s}" has not attribute "{1s}"'.format(
+                    self.__class__.__name__,
+                    name
+                )
+            )
+
+    def get(self, directive):
+        return self.index[directive] if directive in self.index else []
+
+    def dict(self):
+        dict_repr = {
+            slot: getattr(self, slot)
+            for slot in self.__slots__ if slot not in ('index', 'block')
+        }
+
+        dict_repr['block'] = [
+            directive.dict() for directive in self.block
+        ]
+
+        return dict_repr
+
+
+class NGXConfigFile(object):
+    __slots__ = ('index', 'file', 'parsed')
+
+    def __init__(self, file='', parsed=[], **kwargs):
+        self.index = {}
+        self.file = file
+        self.parsed = parsed
+
+        self._setup_parsed()
+
+    def _setup_parsed(self):
+        directives = []
+        for directive_json in self.parsed:
+            directives.append(_init_directive(directive_json))
+            self.__index(directives[-1])
+
+        self.parsed = directives
+
+    def __index(self, directive):
+        idx = self.index.get(directive.directive, [])
+        idx.append(directive)
+        self.index[directive.directive] = idx
+
+    def __contains__(self, item):
+        return item in self.index
+
+    def __getattr__(self, name):
+        if name in self.index:
+            return self.get(name)
+        else:
+            raise AttributeError(
+                '"{0s}" has not attribute "{1s}"'.format(
+                    self.__class__.__name__,
+                    name
+                )
+            )
+
+    def get(self, directive):
+        return self.index[directive] if directive in self.index else []
+
+    def dict(self):
+        dict_repr = {
+            slot: getattr(self, slot)
+            for slot in self.__slots__ if slot not in ('index', 'parsed')
+        }
+
+        dict_repr['parsed'] = [
+            directive.dict() for directive in self.parsed
+        ]
+        return dict_repr
+
+
+class CrossplaneConfig(object):
+    __slots__ = ('index', 'files', 'configs')
+
+    def __init__(self, configs=[]):
+        self.index = {}
+        self.files = []
+        self.configs = configs
+
+        self._setup_configs()
+
+    def _setup_configs(self):
+        configs = []
+        for config_json in self.configs:
+            configs.append(NGXConfigFile(**config_json))
+            self.__index(configs[-1])
+
+        self.configs = configs
+
+    def __index(self, config):
+        self.index[config.file] = config
+        self.files.append(config.file)
+
+    def __contains__(self, item):
+        return item in self.index
+
+    def __getattr__(self, name):
+        if name in self.index:
+            return self.get(name)
+        else:
+            raise AttributeError(
+                '"{0s}" has not attribute "{1s}"'.format(
+                    self.__class__.__name__,
+                    name
+                )
+            )
+
+    def get(self, file):
+        return self.index[file] if file in self.index else None
+
+    def get_include(self, idx):
+        return self.index[self.files[idx]]
+
+    def dict(self):
+        return {
+            'config': [config.dict() for config in self.configs]
+        }
+
+
+def xmap(payload):
+    """
+    Loads a crossplane.parse() payload into a CrossplaneConfig object and
+    returns it.
+    """
+    return CrossplaneConfig(configs=payload['config'])
+
+
+def ximport(filename, **kwargs):
+    """
+    Uses parser to parse an nginx config file and then creates native Python
+    objects from the parsed structure.  These native objects can then be edited
+    and output into a new crossplane structure.
+    """
+    payload = parse(filename, **kwargs)
+    return xmap(payload)

--- a/crossplane/objects.py
+++ b/crossplane/objects.py
@@ -12,10 +12,8 @@ def _init_directive(parent, directive_json):
 class NginxDirective(object):
     __slots__ = ('parent', 'directive', 'line', 'args', 'includes')
 
-    def __init__(self, directive='', line=0, args=[], includes=[], parent=None,
-                 **kwargs):
+    def __init__(self, directive, args, line, includes=[], parent=None):
         self.parent = parent
-
         self.directive = directive
         self.line = line
         self.args = args
@@ -35,7 +33,7 @@ class NginxDirective(object):
         """
         return []
 
-    def dict(self):
+    def to_dict(self):
         result = {}
 
         for slot in self.__slots__:
@@ -50,13 +48,6 @@ class NginxDirective(object):
         Recursively walk the tree to find the containing file.
         """
         return self.parent.file
-
-    @property
-    def location(self):
-        """
-        Return filename, line number of current directive.
-        """
-        return self.file, self.line
 
     def context(self, *args):
         """
@@ -123,16 +114,14 @@ class NginxBlockDirective(NginxDirective):
     def get(self, directive):
         return self.index[directive] if directive in self.index else []
 
-    def dict(self):
+    def to_dict(self):
         result = {}
 
         for slot in self.__slots__:
             if slot not in ('parent', 'index', 'block'):
                 result[slot] = getattr(self, slot)
 
-        result['block'] = [
-            directive.dict() for directive in self.block
-        ]
+        result['block'] = [directive.to_dict() for directive in self.block]
 
         return result
 
@@ -168,16 +157,14 @@ class NginxConfigFile(object):
     def get(self, directive):
         return self.index[directive] if directive in self.index else []
 
-    def dict(self):
+    def to_dict(self):
         result = {}
 
         for slot in self.__slots__:
             if slot not in ('parent', 'index', 'parsed'):
                 result[slot] = getattr(self, slot)
 
-        result['parsed'] = [
-            directive.dict() for directive in self.parsed
-        ]
+        result['parsed'] = [directive.to_dict() for directive in self.parsed]
 
         return result
 
@@ -213,12 +200,10 @@ class CrossplaneConfig(object):
     def get_include(self, idx):
         return self.index[self.files[idx]]
 
-    def dict(self):
+    def to_dict(self):
         result = {}
 
-        result['config'] = [
-            config.dict() for config in self.configs
-        ]
+        result['config'] = [config.to_dict() for config in self.configs]
 
         return result
 

--- a/crossplane/objects.py
+++ b/crossplane/objects.py
@@ -2,22 +2,14 @@
 from .parser import parse
 
 
-#
-# Functions
-#
-
 def _init_directive(parent, directive_json):
     if 'block' in directive_json:
-        return NGXBlockDirective(parent=parent, **directive_json)
+        return NginxBlockDirective(parent=parent, **directive_json)
     else:
-        return NGXDirective(parent=parent, **directive_json)
+        return NginxDirective(parent=parent, **directive_json)
 
 
-#
-# Classes
-#
-
-class NGXDirective(object):
+class NginxDirective(object):
     __slots__ = ('parent', 'directive', 'line', 'args', 'includes')
 
     def __init__(self, directive='', line=0, args=[], includes=[], parent=None,
@@ -102,11 +94,11 @@ class NGXDirective(object):
             return None, None
 
 
-class NGXBlockDirective(NGXDirective):
+class NginxBlockDirective(NginxDirective):
     __slots__ = ('parent', 'index', 'directive', 'line', 'args', 'block')
 
     def __init__(self, block=[], **kwargs):
-        super(NGXBlockDirective, self).__init__(**kwargs)
+        super(NginxBlockDirective, self).__init__(**kwargs)
         self.index = {}
         self.block = block
 
@@ -145,7 +137,7 @@ class NGXBlockDirective(NGXDirective):
         return result
 
 
-class NGXConfigFile(object):
+class NginxConfigFile(object):
     __slots__ = ('parent', 'index', 'file', 'parsed')
 
     def __init__(self, file='', parsed=[], parent=None, **kwargs):
@@ -203,7 +195,7 @@ class CrossplaneConfig(object):
     def _setup_configs(self):
         configs = []
         for config_json in self.configs:
-            configs.append(NGXConfigFile(parent=self, **config_json))
+            configs.append(NginxConfigFile(parent=self, **config_json))
             self.__index(configs[-1])
 
         self.configs = configs

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -17,23 +17,23 @@ def test_load_simple():
 
     # only one file
     xconfigfile = xconfig.get(config)
-    assert isinstance(xconfigfile, crossplane.objects.NGXConfigFile)
+    assert isinstance(xconfigfile, crossplane.objects.NginxConfigFile)
     for directive in ('events', 'http'):
         assert directive in xconfigfile
         assert len(xconfigfile.get(directive)) == 1
 
     events = xconfigfile.get('events')[0]
-    assert isinstance(events, crossplane.objects.NGXBlockDirective)
+    assert isinstance(events, crossplane.objects.NginxBlockDirective)
     assert len(events.get('worker_connections')) > 0
     assert events.get('worker_connections')[0].args == ['1024']
 
     server = xconfigfile.get('http')[0].get('server')[0]
-    assert isinstance(server, crossplane.objects.NGXBlockDirective)
+    assert isinstance(server, crossplane.objects.NginxBlockDirective)
     assert server.get('listen')[0].args == ['127.0.0.1:8080']
     assert server.get('server_name')[0].args == ['default_server']
 
     location = server.get('location')[0]
-    assert isinstance(location, crossplane.objects.NGXBlockDirective)
+    assert isinstance(location, crossplane.objects.NginxBlockDirective)
     assert location.args == ['/']
     assert location.get('return')[0].args == ['200', 'foo bar baz']
 
@@ -69,23 +69,23 @@ def test_load_build_cycle_simple(tmpdir):
 
     # only one file
     xconfigfile = build_xconfig.get(build_file)
-    assert isinstance(xconfigfile, crossplane.objects.NGXConfigFile)
+    assert isinstance(xconfigfile, crossplane.objects.NginxConfigFile)
     for directive in ('events', 'http'):
         assert directive in xconfigfile
         assert len(xconfigfile.get(directive)) == 1
 
     events = xconfigfile.get('events')[0]
-    assert isinstance(events, crossplane.objects.NGXBlockDirective)
+    assert isinstance(events, crossplane.objects.NginxBlockDirective)
     assert len(events.get('worker_connections')) > 0
     assert events.get('worker_connections')[0].args == ['1024']
 
     server = xconfigfile.get('http')[0].get('server')[0]
-    assert isinstance(server, crossplane.objects.NGXBlockDirective)
+    assert isinstance(server, crossplane.objects.NginxBlockDirective)
     assert server.get('listen')[0].args == ['127.0.0.1:8080']
     assert server.get('server_name')[0].args == ['default_server']
 
     location = server.get('location')[0]
-    assert isinstance(location, crossplane.objects.NGXBlockDirective)
+    assert isinstance(location, crossplane.objects.NginxBlockDirective)
     assert location.args == ['/']
     assert location.get('return')[0].args == ['200', 'foo bar baz']
 
@@ -111,22 +111,22 @@ def test_load_build_cycle_with_changes_simple(tmpdir):
 
     # only one file
     xconfigfile = build_xconfig.get(build_file)
-    assert isinstance(xconfigfile, crossplane.objects.NGXConfigFile)
+    assert isinstance(xconfigfile, crossplane.objects.NginxConfigFile)
     for directive in ('events', 'http'):
         assert directive in xconfigfile
         assert len(xconfigfile.get(directive)) == 1
 
     events = xconfigfile.get('events')[0]
-    assert isinstance(events, crossplane.objects.NGXBlockDirective)
+    assert isinstance(events, crossplane.objects.NginxBlockDirective)
     assert len(events.get('worker_connections')) > 0
     assert events.get('worker_connections')[0].args == ['2048']  # changed!
 
     server = xconfigfile.get('http')[0].get('server')[0]
-    assert isinstance(server, crossplane.objects.NGXBlockDirective)
+    assert isinstance(server, crossplane.objects.NginxBlockDirective)
     assert server.get('listen')[0].args == ['127.0.0.1:8080']
     assert server.get('server_name')[0].args == ['default_server']
 
     location = server.get('location')[0]
-    assert isinstance(location, crossplane.objects.NGXBlockDirective)
+    assert isinstance(location, crossplane.objects.NginxBlockDirective)
     assert location.args == ['/']
     assert location.get('return')[0].args == ['200', 'foo bar baz']

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+import os
+
+import crossplane
+
+here = os.path.dirname(__file__)
+
+
+def test_ximport_simple():
+    dirname = os.path.join(here, 'configs', 'simple')
+    config = os.path.join(dirname, 'nginx.conf')
+
+    xconfig = crossplane.ximport(config)
+    assert xconfig is not None
+    assert isinstance(xconfig, crossplane.objects.CrossplaneConfig)
+    assert len(xconfig.configs) == 1
+
+    # only one file
+    xconfigfile = xconfig.get(config)
+    assert isinstance(xconfigfile, crossplane.objects.NGXConfigFile)
+    for directive in ('events', 'http'):
+        assert directive in xconfigfile
+        assert len(xconfigfile.get(directive)) == 1
+
+    events = xconfigfile.get('events')[0]
+    assert isinstance(events, crossplane.objects.NGXBlockDirective)
+    assert events.worker_connections is not None
+    assert events.worker_connections[0].args == ['1024']
+
+    server = xconfigfile.http[0].server[0]
+    assert isinstance(server, crossplane.objects.NGXBlockDirective)
+    assert server.listen[0].args == ['127.0.0.1:8080']
+    assert server.server_name[0].args == ['default_server']
+
+    location = server.location[0]
+    assert isinstance(location, crossplane.objects.NGXBlockDirective)
+    assert location.args == ['/']
+    assert location.get('return')[0].args == ['200', 'foo bar baz']
+
+
+def test_ximport_build_cycle_simple(tmpdir):
+    dirname = os.path.join(here, 'configs', 'simple')
+    config = os.path.join(dirname, 'nginx.conf')
+
+    xconfig = crossplane.ximport(config)
+
+    build_config = crossplane.build(xconfig.dict()['config'][0]['parsed'])
+    build_file = tmpdir.join('build1.conf')
+    build_file.write(build_config)
+    build_xconfig = crossplane.ximport(build_file.strpath)
+
+    assert build_xconfig is not None
+    assert isinstance(build_xconfig, crossplane.objects.CrossplaneConfig)
+    assert len(build_xconfig.configs) == 1
+
+    # only one file
+    xconfigfile = build_xconfig.get(build_file)
+    assert isinstance(xconfigfile, crossplane.objects.NGXConfigFile)
+    for directive in ('events', 'http'):
+        assert directive in xconfigfile
+        assert len(xconfigfile.get(directive)) == 1
+
+    events = xconfigfile.get('events')[0]
+    assert isinstance(events, crossplane.objects.NGXBlockDirective)
+    assert events.worker_connections is not None
+    assert events.worker_connections[0].args == ['1024']
+
+    server = xconfigfile.http[0].server[0]
+    assert isinstance(server, crossplane.objects.NGXBlockDirective)
+    assert server.listen[0].args == ['127.0.0.1:8080']
+    assert server.server_name[0].args == ['default_server']
+
+    location = server.location[0]
+    assert isinstance(location, crossplane.objects.NGXBlockDirective)
+    assert location.args == ['/']
+    assert location.get('return')[0].args == ['200', 'foo bar baz']
+
+
+def test_ximport_build_cycle_with_changes_simple(tmpdir):
+    dirname = os.path.join(here, 'configs', 'simple')
+    config = os.path.join(dirname, 'nginx.conf')
+
+    xconfig = crossplane.ximport(config)
+    xconfigfile = xconfig.get(config)
+
+    # change events worker_connections
+    xconfigfile.get('events')[0].worker_connections[0].args = ['2048']
+
+    build_config = crossplane.build(xconfig.dict()['config'][0]['parsed'])
+    build_file = tmpdir.join('build1.conf')
+    build_file.write(build_config)
+    build_xconfig = crossplane.ximport(build_file.strpath)
+
+    assert build_xconfig is not None
+    assert isinstance(build_xconfig, crossplane.objects.CrossplaneConfig)
+    assert len(build_xconfig.configs) == 1
+
+    # only one file
+    xconfigfile = build_xconfig.get(build_file)
+    assert isinstance(xconfigfile, crossplane.objects.NGXConfigFile)
+    for directive in ('events', 'http'):
+        assert directive in xconfigfile
+        assert len(xconfigfile.get(directive)) == 1
+
+    events = xconfigfile.get('events')[0]
+    assert isinstance(events, crossplane.objects.NGXBlockDirective)
+    assert events.worker_connections is not None
+    assert events.worker_connections[0].args == ['2048']  # changed!
+
+    server = xconfigfile.http[0].server[0]
+    assert isinstance(server, crossplane.objects.NGXBlockDirective)
+    assert server.listen[0].args == ['127.0.0.1:8080']
+    assert server.server_name[0].args == ['default_server']
+
+    location = server.location[0]
+    assert isinstance(location, crossplane.objects.NGXBlockDirective)
+    assert location.args == ['/']
+    assert location.get('return')[0].args == ['200', 'foo bar baz']

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -39,7 +39,6 @@ def test_load_simple():
 
     # some higher level primitives
     assert location.file == config
-    assert location.location == (config, 9)
 
     location_ctx, ctx_parent = location.context('server_name', 'listen')
     assert location_ctx is not None
@@ -58,7 +57,7 @@ def test_load_build_cycle_simple(tmpdir):
 
     xconfig = crossplane.load(config)
 
-    build_config = crossplane.build(xconfig.dict()['config'][0]['parsed'])
+    build_config = crossplane.build(xconfig.to_dict()['config'][0]['parsed'])
     build_file = tmpdir.join('build1.conf')
     build_file.write(build_config)
     build_xconfig = crossplane.load(build_file.strpath)
@@ -100,7 +99,7 @@ def test_load_build_cycle_with_changes_simple(tmpdir):
     # change events worker_connections
     xconfigfile.get('events')[0].get('worker_connections')[0].args = ['2048']
 
-    build_config = crossplane.build(xconfig.dict()['config'][0]['parsed'])
+    build_config = crossplane.build(xconfig.to_dict()['config'][0]['parsed'])
     build_file = tmpdir.join('build1.conf')
     build_file.write(build_config)
     build_xconfig = crossplane.load(build_file.strpath)


### PR DESCRIPTION
* Added new Python classes to represent vairous `crossplane` structures.
* Added translation of crossplane structures to these Python objects and vice-versa.
* Added tests for this...including parsing a file, changing a directive, re-writing the config, and re-importing to verify changes.

Some notes, this is an extremely rough draft / semi-POC.  Some thought has been put into usablity of these objects but not a ton.  As it stands, these python objects are functional and therefore I am opening this PR...but a v2 should seek to improve usability and establish more Pythonic conventions.

With this additional feature core `crossplane` can now:

* Parse NGINX configs
* Write NGINX configs
* Map NGINX configs into Python objects

Which means stitching these primatives together you could conceivably use `crossplane` to:

* Create NGINX configs
* Edit existing NGINX configs
* Copy NGINX configs
* Create NGINX config templates that use/rely on instance specific variables
