### PR TITLE
Fix for failing extension import

### DIFF
--- a/crossplane/__init__.py
+++ b/crossplane/__init__.py
@@ -2,7 +2,7 @@
 from .parser import parse
 from .lexer import lex
 from .builder import build
-from .ext.lua import LuaBlockPlugin
+from crossplane.ext.lua import LuaBlockPlugin
 
 __all__ = ['parse', 'lex', 'build']
 


### PR DESCRIPTION
Was having issues with:
```
/usr/local/lib/python2.7/dist-packages/crossplane/__init__.py:5: in <module>
    from .ext.lua import LuaBlockPlugin
/usr/local/lib/python2.7/dist-packages/gevent/builtins.py:93: in __import__
    result = _import(*args, **kwargs)
E   ImportError: No module named ext.lua
```