### PR TITLE
Added --strict flag to crossplane parse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,9 @@ the schema defined below, and dumps the entire thing as a JSON payload.
 
 .. code-block::
 
-   usage: crossplane parse [-h] [-o OUT] [-i NUM] [--no-catch] [--tb-onerror]
+   usage: crossplane parse [-h] [-o OUT] [-i NUM] [--ignore DIRECTIVES]
+                           [--no-catch] [--tb-onerror] [--single-file]
+                           [--include-comments] [--strict]
                            filename
 
    parses a json payload for an nginx config
@@ -82,6 +84,7 @@ the schema defined below, and dumps the entire thing as a JSON payload.
      --tb-onerror          include tracebacks in config errors
      --single-file         do not include other config files
      --include-comments    include comments in json
+     --strict              raise errors for unknown directives
 
 **Privacy and Security**
 

--- a/crossplane/__main__.py
+++ b/crossplane/__main__.py
@@ -28,14 +28,23 @@ def _dump_payload(obj, fp, indent):
     fp.write(json.dumps(obj, **kwargs) + '\n')
 
 
-def parse(filename, out, indent=None, catch=None, tb_onerror=None, ignore='', single=False, comments=False):
+def parse(filename, out, indent=None, catch=None, tb_onerror=None, ignore='',
+          single=False, comments=False, strict=False):
+
     ignore = ignore.split(',') if ignore else []
 
     def callback(e):
         exc = sys.exc_info() + (10,)
         return ''.join(format_exception(*exc)).rstrip()
 
-    kwargs = {'catch_errors': catch, 'ignore': ignore, 'single': single, 'comments': comments}
+    kwargs = {
+        'catch_errors': catch,
+        'ignore': ignore,
+        'single': single,
+        'comments': comments,
+        'strict': strict
+    }
+
     if tb_onerror:
         kwargs['onerror'] = callback
 
@@ -171,6 +180,7 @@ def parse_args(args=None):
     p.add_argument('--tb-onerror', action='store_true', help='include tracebacks in config errors')
     p.add_argument('--single-file', action='store_true', dest='single', help='do not include other config files')
     p.add_argument('--include-comments', action='store_true', dest='comments', help='include comments in json')
+    p.add_argument('--strict', action='store_true', help='raise errors for unknown directives')
 
     p = create_subparser(build, 'builds an nginx config from a json payload')
     p.add_argument('filename', help='the file with the config payload')

--- a/crossplane/analyzer.py
+++ b/crossplane/analyzer.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-from .errors import \
-    NgxParserDirectiveContextError, NgxParserDirectiveArgumentsError
+from .errors import (
+    NgxParserDirectiveUnknownError,
+    NgxParserDirectiveContextError,
+    NgxParserDirectiveArgumentsError
+)
 
 # bit masks for different directive argument styles
 NGX_CONF_NOARGS = 0x00000001  # 0 args
@@ -1899,9 +1902,14 @@ def enter_block_ctx(stmt, ctx):
     return ctx + (stmt['directive'],)
 
 
-def analyze(fname, stmt, term, ctx=()):
+def analyze(fname, stmt, term, ctx=(), strict=False):
     directive = stmt['directive']
     line = stmt['line']
+
+    # if strict and directive isn't recognized then throw error
+    if strict and directive not in DIRECTIVES:
+        reason = 'unknown directive "%s"' % directive
+        raise NgxParserDirectiveUnknownError(reason, fname, line)
 
     # if we don't know where this directive is allowed and how
     # many arguments it can take then don't bother analyzing it

--- a/crossplane/errors.py
+++ b/crossplane/errors.py
@@ -10,9 +10,9 @@ class NgxParserBaseException(Exception):
 
     def __str__(self):
         if self.lineno is not None:
-            return '{} in {}:{}'.format(*self.args)
+            return '%s in %s:%s' % self.args
         else:
-            return '{} in {}'.format(*self.args)
+            return '%s in %s' % self.args
 
 
 class NgxParserSyntaxError(NgxParserBaseException):
@@ -28,4 +28,8 @@ class NgxParserDirectiveArgumentsError(NgxParserDirectiveError):
 
 
 class NgxParserDirectiveContextError(NgxParserDirectiveError):
+    pass
+
+
+class NgxParserDirectiveUnknownError(NgxParserDirectiveError):
     pass

--- a/crossplane/parser.py
+++ b/crossplane/parser.py
@@ -22,7 +22,8 @@ def _prepare_if_args(stmt):
         args[:] = args[start:end]
 
 
-def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False, comments=False):
+def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
+        comments=False, strict=False):
     """
     Parses an nginx config file and returns a nested dict payload
     
@@ -32,6 +33,7 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False, co
     :param ignore: list or tuple of directives to exclude from the payload
     :param single: bool; if True, including from other files doesn't happen
     :param comments: bool; if True, including comments to json payload
+    :param strict: bool; if True, unrecognized directives raise errors
     :returns: a payload that describes the parsed nginx config
     """
     config_dir = os.path.dirname(filename)
@@ -90,7 +92,6 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False, co
                         "line": lineno,
                         "comment": token[1:]
                     }
-
                     parsed.append(stmt)
                 continue
 
@@ -123,7 +124,7 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False, co
 
             try:
                 # raise errors if this statement is invalid
-                analyze(fname, stmt, token, ctx)
+                analyze(fname, stmt, token, ctx, strict=strict)
             except NgxParserDirectiveError as e:
                 if catch_errors:
                     _handle_error(parsing, e)

--- a/tests/configs/spelling-mistake/nginx.conf
+++ b/tests/configs/spelling-mistake/nginx.conf
@@ -1,0 +1,10 @@
+events {}
+
+http {
+    server {
+        location / {
+            #directive is misspelled
+            proxy_passs http://foo.bar;
+        }
+    }
+}

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -367,6 +367,7 @@ def test_ignore_directives():
         ]
     }
 
+
 def test_config_with_comments():
     dirname = os.path.join(here, 'configs', 'with-comments')
     config = os.path.join(dirname, 'nginx.conf')
@@ -468,6 +469,7 @@ def test_config_with_comments():
        ]
     }
 
+
 def test_config_without_comments():
     dirname = os.path.join(here, 'configs', 'with-comments')
     config = os.path.join(dirname, 'nginx.conf')
@@ -543,4 +545,67 @@ def test_config_without_comments():
              "file" : os.path.join(dirname, 'nginx.conf')
           }
        ]
+    }
+
+
+def test_parse_strict():
+    dirname = os.path.join(here, 'configs', 'spelling-mistake')
+    config = os.path.join(dirname, 'nginx.conf')
+    payload = crossplane.parse(config, comments=True, strict=True)
+    assert payload == {
+        'status' : 'failed',
+        'errors' : [
+            {
+                'file': os.path.join(dirname, 'nginx.conf'),
+                'error': 'unknown directive "proxy_passs" in %s:7' % os.path.join(dirname, 'nginx.conf'),
+                'line': 7
+            }
+        ],
+        'config' : [
+           {
+              'file' : os.path.join(dirname, 'nginx.conf'),
+              'status' : 'failed',
+              'errors' : [
+                  {
+                     'error': 'unknown directive "proxy_passs" in %s:7' % os.path.join(dirname, 'nginx.conf'),
+                     'line': 7
+                  }
+              ],
+              'parsed' : [
+                 {
+                    'directive' : 'events',
+                    'line' : 1,
+                    'args' : [],
+                    'block' : []
+                 },
+                 {
+                    'directive' : 'http',
+                    'line' : 3,
+                    'args' : [],
+                    'block' : [
+                       {
+                          'directive' : 'server',
+                          'line' : 4,
+                          'args' : [],
+                          'block' : [
+                             {
+                                'directive' : 'location',
+                                'line' : 5,
+                                'args' : ['/'],
+                                'block' : [
+                                   {
+                                       'directive' : '#',
+                                       'line' : 6,
+                                       'args' : [],
+                                       'comment': 'directive is misspelled'
+                                   }
+                                ]
+                             }
+                          ]
+                       }
+                    ]
+                 }
+              ]
+           }
+        ]
     }


### PR DESCRIPTION
Added optional argument to `crossplane parse`:

```
  --strict              raise errors for unknown directives
```

This feature addresses issue #30 because misspellings of directives should almost always raise "unknown directive" errors.