### PR TITLE
Fixed error messages for missing semicolons

### DIFF
--- a/crossplane/parser.py
+++ b/crossplane/parser.py
@@ -107,7 +107,7 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
             # parse arguments by reading tokens
             args = stmt['args']
             token, __ = next(tokens)  # disregard line numbers of args
-            while token not in ('{', ';'):
+            while token not in ('{', ';', '}'):
                 stmt['args'].append(token)
                 token, __ = next(tokens)
 
@@ -131,7 +131,10 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
 
                     # if it was a block but shouldn't have been then consume
                     if e.strerror.endswith(' is not terminated by ";"'):
-                        _parse(parsing, tokens, consume=True)
+                        if token != '}':
+                            _parse(parsing, tokens, consume=True)
+                        else:
+                            break
 
                     # keep on parsin'
                     continue

--- a/tests/configs/missing-semicolon/broken-above.conf
+++ b/tests/configs/missing-semicolon/broken-above.conf
@@ -1,0 +1,10 @@
+http {
+    server {
+        location /is-broken {
+            proxy_pass http://is.broken.example
+        }
+        location /not-broken {
+            proxy_pass http://not.broken.example;
+        }
+    }
+}

--- a/tests/configs/missing-semicolon/broken-below.conf
+++ b/tests/configs/missing-semicolon/broken-below.conf
@@ -1,0 +1,10 @@
+http {
+    server {
+        location /not-broken {
+            proxy_pass http://not.broken.example;
+        }
+        location /is-broken {
+            proxy_pass http://is.broken.example
+        }
+    }
+}

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -609,3 +609,127 @@ def test_parse_strict():
            }
         ]
     }
+
+
+def test_parse_missing_semicolon():
+    dirname = os.path.join(here, 'configs', 'missing-semicolon')
+
+    # test correct error is raised when broken proxy_pass is in upper block
+    above_config = os.path.join(dirname, 'broken-above.conf')
+    above_payload = crossplane.parse(above_config)
+    assert above_payload == {
+        "status": "failed",
+        "errors": [
+            {
+                "file": above_config,
+                "error": "directive \"proxy_pass\" is not terminated by \";\" in %s:4" % above_config,
+                "line": 4
+            }
+        ],
+        "config": [
+            {
+                "file": above_config,
+                "status": "failed",
+                "errors": [
+                    {
+                        "error": "directive \"proxy_pass\" is not terminated by \";\" in %s:4" % above_config,
+                        "line": 4
+                    }
+                ],
+                "parsed": [
+                    {
+                        "directive": "http",
+                        "line": 1,
+                        "args": [],
+                        "block": [
+                            {
+                                "directive": "server",
+                                "line": 2,
+                                "args": [],
+                                "block": [
+                                    {
+                                        "directive": "location",
+                                        "line": 3,
+                                        "args": ["/is-broken"],
+                                        "block": []
+                                    },
+                                    {
+                                        "directive": "location",
+                                        "line": 6,
+                                        "args": ["/not-broken"],
+                                        "block": [
+                                            {
+                                                "directive": "proxy_pass",
+                                                "line": 7,
+                                                "args": ["http://not.broken.example"]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    # test correct error is raised when broken proxy_pass is in lower block
+    below_config = os.path.join(dirname, 'broken-below.conf')
+    below_payload = crossplane.parse(below_config)
+    assert below_payload == {
+        "status": "failed",
+        "errors": [
+            {
+                "file": below_config,
+                "error": "directive \"proxy_pass\" is not terminated by \";\" in %s:7" % below_config,
+                "line": 7
+            }
+        ],
+        "config": [
+            {
+                "file": below_config,
+                "status": "failed",
+                "errors": [
+                    {
+                        "error": "directive \"proxy_pass\" is not terminated by \";\" in %s:7" % below_config,
+                        "line": 7
+                    }
+                ],
+                "parsed": [
+                    {
+                        "directive": "http",
+                        "line": 1,
+                        "args": [],
+                        "block": [
+                            {
+                                "directive": "server",
+                                "line": 2,
+                                "args": [],
+                                "block": [
+                                    {
+                                        "directive": "location",
+                                        "line": 3,
+                                        "args": ["/not-broken"],
+                                        "block": [
+                                            {
+                                                "directive": "proxy_pass",
+                                                "line": 4,
+                                                "args": ["http://not.broken.example"]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "directive": "location",
+                                        "line": 6,
+                                        "args": ["/is-broken"],
+                                        "block": []
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }


### PR DESCRIPTION
Essentially error messages weren't getting reported correctly if the last directive in a block didn't end with a semicolon.

Fixes #31 