### PR TITLE
Added --combine flag to parse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,7 @@ the schema defined below, and dumps the entire thing as a JSON payload.
      --ignore DIRECTIVES   ignore directives (comma-separated)
      --no-catch            only collect first error in file
      --tb-onerror          include tracebacks in config errors
+     --combine             use includes to create one single file
      --single-file         do not include other config files
      --include-comments    include comments in json
      --strict              raise errors for unknown directives

--- a/crossplane/__main__.py
+++ b/crossplane/__main__.py
@@ -29,7 +29,7 @@ def _dump_payload(obj, fp, indent):
 
 
 def parse(filename, out, indent=None, catch=None, tb_onerror=None, ignore='',
-          single=False, comments=False, strict=False):
+          single=False, comments=False, strict=False, combine=False):
 
     ignore = ignore.split(',') if ignore else []
 
@@ -40,6 +40,7 @@ def parse(filename, out, indent=None, catch=None, tb_onerror=None, ignore='',
     kwargs = {
         'catch_errors': catch,
         'ignore': ignore,
+        'combine': combine,
         'single': single,
         'comments': comments,
         'strict': strict
@@ -178,6 +179,7 @@ def parse_args(args=None):
     p.add_argument('--ignore', metavar='DIRECTIVES', default='', help='ignore directives (comma-separated)')
     p.add_argument('--no-catch', action='store_false', dest='catch', help='only collect first error in file')
     p.add_argument('--tb-onerror', action='store_true', help='include tracebacks in config errors')
+    p.add_argument('--combine', action='store_true', help='use includes to create one single file')
     p.add_argument('--single-file', action='store_true', dest='single', help='do not include other config files')
     p.add_argument('--include-comments', action='store_true', dest='comments', help='include comments in json')
     p.add_argument('--strict', action='store_true', help='raise errors for unknown directives')

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -248,6 +248,124 @@ def test_includes_globbed():
     }
 
 
+def test_includes_globbed_combined():
+    dirname = os.path.join(here, 'configs', 'includes-globbed')
+    config = os.path.join(dirname, 'nginx.conf')
+    payload = crossplane.parse(config, combine=True)
+    assert payload == {
+        "status": "ok",
+        "errors": [],
+        "config": [
+            {
+                "file": os.path.join(dirname, "nginx.conf"),
+                "status": "ok",
+                "errors": [],
+                "parsed": [
+                    {
+                        "directive": "events",
+                        "args": [],
+                        "file": os.path.join(dirname, "nginx.conf"),
+                        "line": 1,
+                        "block": []
+                    },
+                    {
+                        "directive": "http",
+                        "args": [],
+                        "file": os.path.join(dirname, "http.conf"),
+                        "line": 1,
+                        "block": [
+                            {
+                                "directive": "server",
+                                "args": [],
+                                "file": os.path.join(dirname, "servers", "server1.conf"),
+                                "line": 1,
+                                "block": [
+                                    {
+                                        "directive": "listen",
+                                        "args": ["8080"],
+                                        "file": os.path.join(dirname, "servers", "server1.conf"),
+                                        "line": 2
+                                    },
+                                    {
+                                        "directive": "location",
+                                        "args": ["/foo"],
+                                        "file": os.path.join(dirname, "locations", "location1.conf"),
+                                        "line": 1,
+                                        "block": [
+                                            {
+                                                "directive": "return",
+                                                "args": ["200", "foo"],
+                                                "file": os.path.join(dirname, "locations", "location1.conf"),
+                                                "line": 2
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "directive": "location",
+                                        "args": ["/bar"],
+                                        "file": os.path.join(dirname, "locations", "location2.conf"),
+                                        "line": 1,
+                                        "block": [
+                                            {
+                                                "directive": "return",
+                                                "args": ["200", "bar"],
+                                                "file": os.path.join(dirname, "locations", "location2.conf"),
+                                                "line": 2
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "directive": "server",
+                                "args": [],
+                                "file": os.path.join(dirname, "servers", "server2.conf"),
+                                "line": 1,
+                                "block": [
+                                    {
+                                        "directive": "listen",
+                                        "args": ["8081"],
+                                        "file": os.path.join(dirname, "servers", "server2.conf"),
+                                        "line": 2
+                                    },
+                                    {
+                                        "directive": "location",
+                                        "args": ["/foo"],
+                                        "file": os.path.join(dirname, "locations", "location1.conf"),
+                                        "line": 1,
+                                        "block": [
+                                            {
+                                                "directive": "return",
+                                                "args": ["200", "foo"],
+                                                "file": os.path.join(dirname, "locations", "location1.conf"),
+                                                "line": 2
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "directive": "location",
+                                        "args": ["/bar"],
+                                        "file": os.path.join(dirname, "locations", "location2.conf"),
+                                        "line": 1,
+                                        "block": [
+                                            {
+                                                "directive": "return",
+                                                "args": ["200", "bar"],
+                                                "file": os.path.join(dirname, "locations", "location2.conf"),
+                                                "line": 2
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+
 def test_includes_single():
     dirname = os.path.join(here, 'configs', 'includes-regular')
     config = os.path.join(dirname, 'nginx.conf')


### PR DESCRIPTION
With the new `--combine` flag, you can make it so that crossplane parse will use the include directive logic to combine all the config files into one.