### PR TITLE
Fixed bug with empty map values

### DIFF
--- a/crossplane/builder.py
+++ b/crossplane/builder.py
@@ -82,6 +82,9 @@ def build(payload, indent=4, tabs=False, header=False):
         for obj in objs:
             directive = obj['directive']
 
+            if directive == '':
+                directive = _enquote(directive)
+
             if directive in EXTERNAL_BUILDERS:
                 external_builder = EXTERNAL_BUILDERS[directive]
                 built = external_builder(obj, padding, state, indent, tabs)

--- a/tests/configs/empty-value-map/nginx.conf
+++ b/tests/configs/empty-value-map/nginx.conf
@@ -1,0 +1,8 @@
+events {
+}
+http {
+    map string $variable {
+        '' $arg;
+        *.example.com '';
+    }
+}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -230,3 +230,7 @@ def test_compare_parsed_and_built_messy(tmpdir):
 
 def test_compare_parsed_and_built_messy_with_comments(tmpdir):
     compare_parsed_and_built('with-comments', 'nginx.conf', tmpdir, comments=True)
+
+
+def test_compare_parsed_and_built_messy_with_comments(tmpdir):
+    compare_parsed_and_built('empty-value-map', 'nginx.conf', tmpdir)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -232,5 +232,5 @@ def test_compare_parsed_and_built_messy_with_comments(tmpdir):
     compare_parsed_and_built('with-comments', 'nginx.conf', tmpdir, comments=True)
 
 
-def test_compare_parsed_and_built_messy_with_comments(tmpdir):
+def test_compare_parsed_and_built_empty_map_values(tmpdir):
     compare_parsed_and_built('empty-value-map', 'nginx.conf', tmpdir)


### PR DESCRIPTION
When stuff like this was parsed and rebuilt:
```nginx
map string $variable {
     '' $arg;
}
```
The "empty" key would be lost like this:
```nginx
map string $variable {
     $arg;
}
```