### PR TITLE
Added handling for quoted braces and semicolons

### DIFF
--- a/crossplane/__main__.py
+++ b/crossplane/__main__.py
@@ -108,8 +108,10 @@ def build(filename, dirname=None, force=False, indent=4, tabs=False,
 
 def lex(filename, out, indent=None, line_numbers=False):
     payload = list(lex_file(filename))
-    if not line_numbers:
-        payload = [token for token, lineno in payload]
+    if line_numbers:
+        payload = [(token, lineno) for token, lineno, quoted in payload]
+    else:
+        payload = [token for token, lineno, quoted in payload]
     _dump_payload(payload, out, indent=indent)
 
 

--- a/crossplane/parser.py
+++ b/crossplane/parser.py
@@ -72,15 +72,15 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
         parsed = []
 
         # parse recursively by pulling from a flat stream of tokens
-        for token, lineno in tokens:
+        for token, lineno, quoted in tokens:
             # we are parsing a block, so break if it's closing
-            if token == '}':
+            if token == '}' and not quoted:
                 break
 
             # if we are consuming, then just continue until end of context
             if consume:
                 # if we find a block inside this context, consume it too
-                if token == '{':
+                if token == '{' and not quoted:
                     _parse(parsing, tokens, consume=True)
                 continue
 
@@ -102,7 +102,7 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
                 }
 
             # if token is comment
-            if directive.startswith('#'):
+            if directive.startswith('#') and not quoted:
                 if comments:
                     stmt['directive'] = '#'
                     stmt['comment'] = token[1:]
@@ -113,15 +113,15 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
 
             # parse arguments by reading tokens
             args = stmt['args']
-            token, __ = next(tokens)  # disregard line numbers of args
-            while token not in ('{', ';', '}'):
+            token, __, quoted = next(tokens)  # disregard line numbers of args
+            while token not in ('{', ';', '}') or quoted:
                 stmt['args'].append(token)
-                token, __ = next(tokens)
+                token, __, quoted = next(tokens)
 
             # consume the directive if it is ignored and move on
             if stmt['directive'] in ignore:
                 # if this directive was a block consume it too
-                if token == '{':
+                if token == '{' and not quoted:
                     _parse(parsing, tokens, consume=True)
                 continue
 
@@ -138,7 +138,7 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
 
                     # if it was a block but shouldn't have been then consume
                     if e.strerror.endswith(' is not terminated by ";"'):
-                        if token != '}':
+                        if token != '}' and not quoted:
                             _parse(parsing, tokens, consume=True)
                         else:
                             break
@@ -183,7 +183,7 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
                     stmt['includes'].append(index)
 
             # if this statement terminated with '{' then it is a block
-            if token == '{':
+            if token == '{' and not quoted:
                 inner = enter_block_ctx(stmt, ctx)  # get context for block
                 stmt['block'] = _parse(parsing, tokens, ctx=inner)
 

--- a/tests/configs/quoted-right-brace/nginx.conf
+++ b/tests/configs/quoted-right-brace/nginx.conf
@@ -1,0 +1,16 @@
+events {}
+http {
+    log_format main escape=json
+        '{ "@timestamp": "$time_iso8601", '
+          '"server_name": "$server_name", '
+          '"host": "$host", '
+          '"status": "$status", '
+          '"request": "$request", '
+          '"uri": "$uri", '
+          '"args": "$args", '
+          '"https": "$https", '
+          '"request_method": "$request_method", '
+          '"referer": "$http_referer", '
+          '"agent": "$http_user_agent"'
+        '}';
+}

--- a/tests/ext/test_lua.py
+++ b/tests/ext/test_lua.py
@@ -9,7 +9,7 @@ def test_lex_lua_block_simple():
     dirname = os.path.join(tests_dir, 'configs', 'lua-block-simple')
     config = os.path.join(dirname, 'nginx.conf')
     tokens = crossplane.lex(config)
-    assert list(tokens) == [
+    assert list((token, line) for token, line, quoted in tokens) == [
         ('http', 1),
         ('{', 1),
         ('init_by_lua_block', 2),
@@ -75,7 +75,7 @@ def test_lex_lua_block_larger():
     dirname = os.path.join(tests_dir, 'configs', 'lua-block-larger')
     config = os.path.join(dirname, 'nginx.conf')
     tokens = crossplane.lex(config)
-    assert list(tokens) == [
+    assert list((token, line) for token, line, quoted in tokens) == [
         ('http', 1),
         ('{', 1),
         ('content_by_lua_block', 2),
@@ -126,7 +126,7 @@ def test_lex_lua_block_tricky():
     dirname = os.path.join(tests_dir, 'configs', 'lua-block-tricky')
     config = os.path.join(dirname, 'nginx.conf')
     tokens = crossplane.lex(config)
-    assert list(tokens) == [
+    assert list((token, line) for token, line, quoted in tokens) == [
         ('http', 1),
         ('{', 1),
         ('server', 2),

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -9,7 +9,7 @@ def test_simple_config():
     dirname = os.path.join(here, 'configs', 'simple')
     config = os.path.join(dirname, 'nginx.conf')
     tokens = crossplane.lex(config)
-    assert list(tokens) == [
+    assert list((token, line) for token, line, quoted in tokens) == [
         ('events', 1), ('{', 1), ('worker_connections', 2), ('1024', 2),
         (';', 2), ('}', 3), ('http', 5), ('{', 5), ('server', 6), ('{', 6),
         ('listen', 7), ('127.0.0.1:8080', 7), (';', 7), ('server_name', 8),
@@ -23,7 +23,7 @@ def test_with_config_comments():
     dirname = os.path.join(here, 'configs', 'with-comments')
     config = os.path.join(dirname, 'nginx.conf')
     tokens = crossplane.lex(config)
-    assert list(tokens) == [
+    assert list((token, line) for token, line, quoted in tokens) == [
         ('events', 1), ('{', 1), ('worker_connections', 2), ('1024', 2),
         (';', 2), ('}', 3),('#comment', 4), ('http', 5), ('{', 5),
         ('server', 6), ('{', 6), ('listen', 7), ('127.0.0.1:8080', 7),
@@ -38,7 +38,7 @@ def test_messy_config():
     dirname = os.path.join(here, 'configs', 'messy')
     config = os.path.join(dirname, 'nginx.conf')
     tokens = crossplane.lex(config)
-    assert list(tokens) == [
+    assert list((token, line) for token, line, quoted in tokens) == [
         ('user', 1), ('nobody', 1), (';', 1),
         ('# hello\\n\\\\n\\\\\\n worlddd  \\#\\\\#\\\\\\# dfsf\\n \\\\n \\\\\\n ', 2),
         ('events', 3), ('{', 3), ('worker_connections', 3), ('2048', 3),
@@ -73,7 +73,22 @@ def test_quote_behavior():
     dirname = os.path.join(here, 'configs', 'quote-behavior')
     config = os.path.join(dirname, 'nginx.conf')
     tokens = crossplane.lex(config)
-    assert list(token for token, line in tokens) == [
+    assert list(token for token, line, quoted in tokens) == [
         'outer-quote', 'left', '-quote', 'right-"quote"', 'inner"-"quote', ';',
         '', '', 'left-empty', 'right-empty""', 'inner""empty', 'right-empty-single"', ';',
+    ]
+
+
+def test_quoted_right_brace():
+    dirname = os.path.join(here, 'configs', 'quoted-right-brace')
+    config = os.path.join(dirname, 'nginx.conf')
+    tokens = crossplane.lex(config)
+    assert list(token for token, line, quoted in tokens) == [
+        'events', '{', '}', 'http', '{', 'log_format', 'main', 'escape=json',
+        '{ "@timestamp": "$time_iso8601", ', '"server_name": "$server_name", ',
+        '"host": "$host", ', '"status": "$status", ',
+        '"request": "$request", ', '"uri": "$uri", ', '"args": "$args", ',
+        '"https": "$https", ', '"request_method": "$request_method", ',
+        '"referer": "$http_referer", ', '"agent": "$http_user_agent"', '}',
+        ';', '}'
     ]


### PR DESCRIPTION
Configs with quoted `{`, `}`, or `;` characters were blowing up because the quoted characters weren't being treated like strings.