### PR TITLE
Fixed handling for quoted right braces in crossplane build

### DIFF
--- a/crossplane/builder.py
+++ b/crossplane/builder.py
@@ -29,8 +29,6 @@ def _escape(string):
 def _needs_quotes(string):
     if string == '':
         return True
-    elif string in DELIMITERS:
-        return False
 
     # lexer should throw an error when variable expansion syntax
     # is messed up, but just wrap it in quotes for now I guess
@@ -38,7 +36,7 @@ def _needs_quotes(string):
 
     # arguments can't start with variable expansion syntax
     char = next(chars)
-    if char.isspace() or char in ('{', ';', '"', "'", '${'):
+    if char.isspace() or char in ('{', '}', ';', '"', "'", '${'):
         return True
 
     expanding = False

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -252,3 +252,7 @@ def test_compare_parsed_and_built_empty_map_values(tmpdir):
 
 def test_compare_parsed_and_built_russian_text(tmpdir):
     compare_parsed_and_built('russian-text', 'nginx.conf', tmpdir)
+
+
+def test_compare_parsed_and_built_quoted_right_brace(tmpdir):
+    compare_parsed_and_built('quoted-right-brace', 'nginx.conf', tmpdir)


### PR DESCRIPTION
for `crossplane build` args that started with `}` weren't getting quoted