### PR TITLE
Added crossplane.format

### DIFF
--- a/crossplane/__init__.py
+++ b/crossplane/__init__.py
@@ -2,9 +2,10 @@
 from .parser import parse
 from .lexer import lex
 from .builder import build
+from .formatter import format
 from .ext.lua import LuaBlockPlugin
 
-__all__ = ['parse', 'lex', 'build']
+__all__ = ['parse', 'lex', 'build', 'format']
 
 __title__ = 'crossplane'
 __summary__ = 'Reliable and fast NGINX configuration file parser.'

--- a/crossplane/__main__.py
+++ b/crossplane/__main__.py
@@ -9,7 +9,7 @@ from . import __version__
 from .lexer import lex as lex_file
 from .parser import parse as parse_file
 from .builder import build as build_string, build_files, _enquote, DELIMITERS
-from .errors import NgxParserBaseException
+from .formatter import format as format_file
 from .compat import json, input
 
 
@@ -123,15 +123,9 @@ def minify(filename, out):
     out.write('\n')
 
 
-def format(filename, out, indent=None, tabs=False):
-    payload = parse_file(filename)
-    parsed = payload['config'][0]['parsed']
-    if payload['status'] == 'ok':
-        output = build_string(parsed, indent=indent, tabs=tabs) + '\n'
-        out.write(output)
-    else:
-        e = payload['errors'][0]
-        raise NgxParserBaseException(e['error'], e['file'], e['line'])
+def format(filename, out, indent=4, tabs=False):
+    output = format_file(filename, indent=indent, tabs=tabs)
+    out.write(output + '\n')
 
 
 class _SubparserHelpFormatter(RawDescriptionHelpFormatter):

--- a/crossplane/analyzer.py
+++ b/crossplane/analyzer.py
@@ -1902,7 +1902,9 @@ def enter_block_ctx(stmt, ctx):
     return ctx + (stmt['directive'],)
 
 
-def analyze(fname, stmt, term, ctx=(), strict=False):
+def analyze(fname, stmt, term, ctx=(), strict=False, check_ctx=True,
+        check_args=True):
+
     directive = stmt['directive']
     line = stmt['line']
 
@@ -1920,13 +1922,16 @@ def analyze(fname, stmt, term, ctx=(), strict=False):
     n_args = len(args)
 
     masks = DIRECTIVES[directive]
-    ctx_mask = CONTEXTS[ctx]
 
     # if this directive can't be used in this context then throw an error
-    masks = [mask for mask in masks if mask & ctx_mask]
-    if not masks:
-        reason = '"%s" directive is not allowed here' % directive
-        raise NgxParserDirectiveContextError(reason, fname, line)
+    if check_ctx:
+        masks = [mask for mask in masks if mask & CONTEXTS[ctx]]
+        if not masks:
+            reason = '"%s" directive is not allowed here' % directive
+            raise NgxParserDirectiveContextError(reason, fname, line)
+
+    if not check_args:
+        return
 
     valid_flag = lambda x: x.lower() in ('on', 'off')
 

--- a/crossplane/formatter.py
+++ b/crossplane/formatter.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from .errors import NgxParserBaseException
+from .builder import build
+from .parser import parse
+
+
+def format(filename, indent=4, tabs=False):
+    payload = parse(filename, single=True, check_ctx=False, check_args=False)
+
+    if payload['status'] != 'ok':
+        e = payload['errors'][0]
+        raise NgxParserBaseException(e['error'], e['file'], e['line'])
+
+    parsed = payload['config'][0]['parsed']
+    output = build(parsed, indent=indent, tabs=tabs)
+    return output

--- a/crossplane/parser.py
+++ b/crossplane/parser.py
@@ -23,10 +23,11 @@ def _prepare_if_args(stmt):
 
 
 def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
-        comments=False, strict=False, combine=False):
+        comments=False, strict=False, combine=False, check_ctx=True,
+        check_args=True):
     """
     Parses an nginx config file and returns a nested dict payload
-    
+
     :param filename: string contianing the name of the config file to parse
     :param onerror: function that determines what's saved in "callback"
     :param catch_errors: bool; if False, parse stops after first error
@@ -35,6 +36,8 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
     :param single: bool; if True, including from other files doesn't happen
     :param comments: bool; if True, including comments to json payload
     :param strict: bool; if True, unrecognized directives raise errors
+    :param check_ctx: bool; if True, runs context analysis on directives
+    :param check_args: bool; if True, runs arg count analysis on directives
     :returns: a payload that describes the parsed nginx config
     """
     config_dir = os.path.dirname(filename)
@@ -131,7 +134,10 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
 
             try:
                 # raise errors if this statement is invalid
-                analyze(fname, stmt, token, ctx, strict=strict)
+                analyze(
+                    fname=fname, stmt=stmt, term=token, ctx=ctx, strict=strict,
+                    check_ctx=check_ctx, check_args=check_args
+                )
             except NgxParserDirectiveError as e:
                 if catch_errors:
                     _handle_error(parsing, e)

--- a/tests/configs/bad-args/nginx.conf
+++ b/tests/configs/bad-args/nginx.conf
@@ -1,0 +1,3 @@
+user;
+events {}
+http {}

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+import os
+
+import crossplane
+from . import here
+
+
+def test_format_messy_config():
+    dirname = os.path.join(here, 'configs', 'messy')
+    config = os.path.join(dirname, 'nginx.conf')
+    output = crossplane.format(config)
+    assert output == '\n'.join([
+        'user nobody;',
+        'events {',
+        '    worker_connections 2048;',
+        '}',
+        'http {',
+        '    access_log off;',
+        '    default_type text/plain;',
+        '    error_log off;',
+        '    server {',
+        '        listen 8083;',
+        r"""        return 200 'Ser" \' \' ver\\ \ $server_addr:\$server_port\n\nTime: $time_local\n\n';""",
+        '    }',
+        '    server {',
+        '        listen 8080;',
+        '        root /usr/share/nginx/html;',
+        "        location ~ '/hello/world;' {",
+        '            return 301 /status.html;',
+        '        }',
+        '        location /foo {',
+        '        }',
+        '        location /bar {',
+        '        }',
+        '        location /\{\;\}\ #\ ab {',
+        '        }',
+        '        if ($request_method = P\{O\)\###\;ST) {',
+        '        }',
+        '        location /status.html {',
+        "            try_files '/abc/${uri} /abc/${uri}.html' =404;",
+        '        }',
+        r"        location '/sta;\n                    tus' {",
+        '            return 302 /status.html;',
+        '        }',
+        '        location /upstream_conf {',
+        '            return 200 /status.html;',
+        '        }',
+        '    }',
+        '    server {',
+        '    }',
+        '}'
+    ])
+
+
+def test_format_not_main_file():
+    dirname = os.path.join(here, 'configs', 'includes-globbed', 'servers')
+    config = os.path.join(dirname, 'server1.conf')
+    output = crossplane.format(config)
+    assert output == '\n'.join([
+        'server {',
+        '    listen 8080;',
+        '    include locations/*.conf;',
+        '}'
+    ])
+
+
+def test_format_args_not_analyzed():
+    dirname = os.path.join(here, 'configs', 'bad-args')
+    config = os.path.join(dirname, 'nginx.conf')
+    output = crossplane.format(config)
+    assert output == '\n'.join([
+        'user;',
+        'events {',
+        '}',
+        'http {',
+        '}'
+    ])


### PR DESCRIPTION
`crossplane format` should now work on files other than the main config. Also, it doesn't do context or argument analysis anymore. It just formats whatever it's given.

This addresses https://github.com/nginxinc/crossplane/issues/58.