### PR TITLE
Added support for comments between arguments

### DIFF
--- a/tests/configs/comments-between-args/nginx.conf
+++ b/tests/configs/comments-between-args/nginx.conf
@@ -1,0 +1,7 @@
+http { #comment 1
+    log_format #comment 2
+        \#arg\ 1 #comment 3
+        '#arg 2' #comment 4
+        #comment 5
+        ;
+}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -196,6 +196,37 @@ def test_build_with_quoted_unicode():
     assert built == u"env 'русский текст';"
 
 
+def test_build_multiple_comments_on_one_line():
+    payload = [
+        {
+            "directive": "#",
+            "line": 1,
+            "args": [],
+            "comment": "comment1"
+        },
+        {
+            "directive": "user",
+            "line": 2,
+            "args": ["root"]
+        },
+        {
+            "directive": "#",
+            "line": 2,
+            "args": [],
+            "comment": "comment2"
+        },
+        {
+            "directive": "#",
+            "line": 2,
+            "args": [],
+            "comment": "comment3"
+        }
+    ]
+    built = crossplane.build(payload, indent=4, tabs=False)
+    assert built == '#comment1\nuser root; #comment2 #comment3'
+
+
+
 def test_build_files_with_missing_status_and_errors(tmpdir):
     assert len(tmpdir.listdir()) == 0
     payload = {

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -582,7 +582,7 @@ def test_config_with_comments():
                 }
              ],
              "status" : "ok",
-             "file" : os.path.join(dirname, 'nginx.conf')
+             "file" : config
           }
        ]
     }
@@ -909,6 +909,67 @@ def test_combine_parsed_missing_values():
                         "line": 2,
                         "args": [],
                         "block": []
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def test_comments_between_args():
+    dirname = os.path.join(here, 'configs', 'comments-between-args')
+    config = os.path.join(dirname, 'nginx.conf')
+    payload = crossplane.parse(config, comments=True)
+    assert payload == {
+        'status': 'ok',
+        'errors': [],
+        'config': [
+            {
+                'file': config,
+                'status': 'ok',
+                'errors': [],
+                'parsed': [
+                    {
+                        'directive': 'http',
+                        'line': 1,
+                        'args': [],
+                        'block': [
+                            {
+                                'directive': '#',
+                                'line': 1,
+                                'args': [],
+                                'comment': 'comment 1'
+                            },
+                            {
+                                'directive': 'log_format',
+                                'line': 2,
+                                'args': ['\\#arg\\ 1', '#arg 2']
+                            },
+                            {
+                                'directive': '#',
+                                'line': 2,
+                                'args': [],
+                                'comment': 'comment 2'
+                            },
+                            {
+                                'directive': '#',
+                                'line': 2,
+                                'args': [],
+                                'comment': 'comment 3'
+                            },
+                            {
+                                'directive': '#',
+                                'line': 2,
+                                'args': [],
+                                'comment': 'comment 4'
+                            },
+                            {
+                                'directive': '#',
+                                'line': 2,
+                                'args': [],
+                                'comment': 'comment 5'
+                            }
+                        ]
                     }
                 ]
             }


### PR DESCRIPTION
Take this for example:
```nginx
http { #comment 1
    log_format #comment 2
        \#arg\ 1 #comment 3
        '#arg 2' #comment 4
        #comment 5
        ;
}
```
Before this change, comments 2-5 would be read as arguments. Now they'll all be parsed as comments with the same line number as the log_format directive.