### PR TITLE
Modified builder._enquote() to not use 'unicode-internal'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - python: 3.5
     - python: 3.6
     - python: 3.7
+    - python: 3.8
       sudo: true
     - python: pypy
 install:

--- a/crossplane/builder.py
+++ b/crossplane/builder.py
@@ -66,7 +66,6 @@ def _enquote(arg):
         arg = ESCAPE_SEQUENCES_RE.sub(_replace_escape_sequences, arg)
         arg = unicode(arg, 'utf-8')
     else:
-        arg = codecs.decode(arg, 'unicode-internal')
         arg = repr(arg).replace('\\\\', '\\')
 
     return arg

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ addopts = -vv --showlocals --disable-warnings -rf -p no:warnings
 testpaths = tests/
 
 [tox]
-envlist = py26, py27, py34, py35, py36, py37, pypy
+envlist = py26, py27, py34, py35, py36, py37, pypy, py38
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
The codec `unicode-internal` has been long deprecated in Python 3.x and was formally removed in Python 3.8

Decoding to `unicode-internal` is removed from `builder._enquote()` for Python 3.x