### PR TITLE
Bugfix: Wrong filenames after includes in certain scenarios

### DIFF
--- a/crossplane/parser.py
+++ b/crossplane/parser.py
@@ -70,10 +70,9 @@ def parse(filename, onerror=None, catch_errors=True, ignore=(), single=False,
         payload['errors'].append(payload_error)
 
     def _handle_include(parsing, ctx, stmt):
-        args = stmt['args']
-        pattern = args[0]
-        if not os.path.isabs(args[0]):
-            pattern = os.path.join(config_dir, args[0])
+        pattern = stmt['args'][0]
+        if not os.path.isabs(pattern):
+            pattern = os.path.join(config_dir, pattern)
 
         stmt['includes'] = []
 

--- a/tests/configs/includes-regular-combined/conf.d/bar.conf
+++ b/tests/configs/includes-regular-combined/conf.d/bar.conf
@@ -1,0 +1,2 @@
+# this file should never be included
+asdfasdfasdfasdfasdfasdfasdfasdfasdf

--- a/tests/configs/includes-regular-combined/conf.d/foo.conf
+++ b/tests/configs/includes-regular-combined/conf.d/foo.conf
@@ -1,0 +1,2 @@
+# this file should never be included
+asdfasdfasdfasdfasdfasdfasdfasdfasdf

--- a/tests/configs/includes-regular-combined/conf.d/server.conf
+++ b/tests/configs/includes-regular-combined/conf.d/server.conf
@@ -1,0 +1,15 @@
+server {
+    listen      127.0.0.1:8080;
+    server_name default_server;
+    include     foo.conf;
+
+    location /A {
+        return 200 'A';
+    }
+
+    location /B {
+        return 200 'B';
+    }
+
+    include     bar.conf;
+}

--- a/tests/configs/includes-regular-combined/foo.conf
+++ b/tests/configs/includes-regular-combined/foo.conf
@@ -1,0 +1,3 @@
+location /foo {
+    return 200 'foo';
+}

--- a/tests/configs/includes-regular-combined/nginx.conf
+++ b/tests/configs/includes-regular-combined/nginx.conf
@@ -1,0 +1,4 @@
+events {}
+http {
+    include conf.d/server.conf;
+}

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -108,6 +108,111 @@ def test_includes_regular():
         ]
     }
 
+def test_includes_regular_combined():
+    dirname = os.path.join(here, 'configs', 'includes-regular-combined')
+    config = os.path.join(dirname, 'nginx.conf')
+    payload = crossplane.parse(config, combine=True)
+    assert payload == {
+        'status': 'failed',
+        'errors': [
+            {
+                'file': os.path.join(dirname, 'conf.d', 'server.conf'),
+                'error': '[Errno 2] No such file or directory: %r' % os.path.join(dirname, 'bar.conf'),
+                'line': 14
+            }
+        ],
+        'config': [
+            {
+                'file': os.path.join(dirname, 'nginx.conf'),
+                'status': 'failed',
+                'errors': [
+                    {
+                        'error': '[Errno 2] No such file or directory: %r' % os.path.join(dirname, 'bar.conf'),
+                        'line': 14
+                    }
+                ],
+                'parsed': [
+                    {
+                        'directive': 'events',
+                        'file': os.path.join(dirname, 'nginx.conf'),
+                        'line': 1,
+                        'args': [],
+                        'block': []
+                    },
+                    {
+                        'directive': 'http',
+                        'file': os.path.join(dirname, 'nginx.conf'),
+                        'line': 2,
+                        'args': [],
+                        'block': [
+                            {
+                                'file': os.path.join(dirname, 'conf.d', 'server.conf'),
+                                'directive': 'server',
+                                'line': 1,
+                                'args': [],
+                                'block': [
+                                    {
+                                        'file': os.path.join(dirname, 'conf.d', 'server.conf'),
+                                        'directive': 'listen',
+                                        'line': 2,
+                                        'args': ['127.0.0.1:8080']
+                                    },
+                                    {
+                                        'file': os.path.join(dirname, 'conf.d', 'server.conf'),
+                                        'directive': 'server_name',
+                                        'line': 3,
+                                        'args': ['default_server']
+                                    },
+                                    {
+                                        'file': os.path.join(dirname, 'foo.conf'),
+                                        'directive': 'location',
+                                        'line': 1,
+                                        'args': ['/foo'],
+                                        'block': [
+                                            {
+                                                'file': os.path.join(dirname, 'foo.conf'),
+                                                'directive': 'return',
+                                                'line': 2,
+                                                'args': ['200', 'foo']
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'file': os.path.join(dirname, 'conf.d', 'server.conf'),
+                                        'directive': 'location',
+                                        'line': 6,
+                                        'args': ['/A'],
+                                        'block': [
+                                            {
+                                                'file': os.path.join(dirname, 'conf.d', 'server.conf'),
+                                                'directive': 'return',
+                                                'line': 7,
+                                                'args': ['200', 'A']
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'file': os.path.join(dirname, 'conf.d', 'server.conf'),
+                                        'directive': 'location',
+                                        'line': 10,
+                                        'args': ['/B'],
+                                        'block': [
+                                            {
+                                                'file': os.path.join(dirname, 'conf.d', 'server.conf'),
+                                                'directive': 'return',
+                                                'line': 11,
+                                                'args': ['200', 'B']
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
 
 def test_includes_globbed():
     dirname = os.path.join(here, 'configs', 'includes-globbed')


### PR DESCRIPTION
### Proposed changes

This fixes a bug that occurs when an include exists in the middle of a file and `Combine=True` is set.  The directives that appear after the include in the outer file will have the wrong filename on them, subject to the number of directives in the included file.

The failing test in the first commit exposes the bug.  This bug was caused by a loop variable mutating the value of a variable by the same name in an outer scope.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/crossplane/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
