### PR TITLE
Make `http` `types` directives analysable

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Contributors
 * Raymond Lau <raymond.lau.ca@gmail.com> `@Raymond26 <https://github.com/Raymond26>`_
 * Luca Comellini <luca.com@gmail.com> `@lucacome <https://github.com/lucacome>`_
 * Ron Vider <viderron@gmail.com> `@RonVider <https://github.com/RonVider>`_
+* Chris Novakovic <chris@chrisn.me.uk> `@chrisnovakovic <https://github.com/chrisnovakovic>`_

--- a/tests/configs/types/nginx.conf
+++ b/tests/configs/types/nginx.conf
@@ -1,0 +1,7 @@
+http {
+    types {
+        text/html  html;
+        image/gif  gif;
+        image/jpeg jpg jpeg;
+    }
+}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -226,6 +226,49 @@ def test_build_multiple_comments_on_one_line():
     assert built == '#comment1\nuser root; #comment2 #comment3'
 
 
+def test_build_types():
+    payload = [
+        {
+            'directive': 'http',
+            'line': 1,
+            'args': [],
+            'block': [
+                {
+                    'directive': 'types',
+                    'line': 2,
+                    'args': [],
+                    'block': [
+                        {
+                            'directive': 'text/html',
+                            'line': 3,
+                            'args': ['html']
+                        },
+                        {
+                            'directive': 'image/gif',
+                            'line': 4,
+                            'args': ['gif']
+                        },
+                        {
+                            'directive': 'image/jpeg',
+                            'line': 5,
+                            'args': ['jpg', 'jpeg']
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+    built = crossplane.build(payload, indent=4, tabs=False)
+    assert built == '\n'.join([
+        'http {',
+        '    types {',
+        '        text/html html;',
+        '        image/gif gif;',
+        '        image/jpeg jpg jpeg;',
+        '    }',
+        '}'
+    ])
+
 
 def test_build_files_with_missing_status_and_errors(tmpdir):
     assert len(tmpdir.listdir()) == 0

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -975,3 +975,58 @@ def test_comments_between_args():
             }
         ]
     }
+
+
+def test_types_checks():
+    dirname = os.path.join(here, 'configs', 'types')
+    config = os.path.join(dirname, 'nginx.conf')
+    payload = crossplane.parse(
+        config,
+        strict=True,
+        check_ctx=True,
+        check_args=True,
+    )
+
+    # Check that strict mode doesn't raise errors when parsing http types blocks
+    assert payload == {
+        'status': 'ok',
+        'errors': [],
+        'config': [
+            {
+                'file': os.path.join(dirname, 'nginx.conf'),
+                'status': 'ok',
+                'errors': [],
+                'parsed': [
+                    {
+                        'directive': 'http',
+                        'line': 1,
+                        'args': [],
+                        'block': [
+                            {
+                                'directive': 'types',
+                                'line': 2,
+                                'args': [],
+                                'block': [
+                                    {
+                                        'directive': 'text/html',
+                                        'line': 3,
+                                        'args': ['html']
+                                    },
+                                    {
+                                        'directive': 'image/gif',
+                                        'line': 4,
+                                        'args': ['gif']
+                                    },
+                                    {
+                                        'directive': 'image/jpeg',
+                                        'line': 5,
+                                        'args': ['jpg', 'jpeg']
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }


### PR DESCRIPTION
### Proposed changes

The syntax of `http` `types` blocks is distinct, in that their child directives are arbitrary MIME types - they therefore can't be analysed when `strict` or `check_ctx` are enabled, and no meaningful analysis can be performed when `check_args` is enabled because the arity of child directives is unknown. Skip the checks performed when `strict` and `check_ctx` are enabled, and hint to the analyser that all directives inside a `types` block accept one or more arguments so that a meaningful check can be performed when `check_args` is enabled.

Fixes #101.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/crossplane/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork