### PR TITLE
Make `map` and `types` directives analysable

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Contributors
 * Raymond Lau <raymond.lau.ca@gmail.com> `@Raymond26 <https://github.com/Raymond26>`_
 * Luca Comellini <luca.com@gmail.com> `@lucacome <https://github.com/lucacome>`_
 * Ron Vider <viderron@gmail.com> `@RonVider <https://github.com/RonVider>`_
+* Chris Novakovic <chris@chrisn.me.uk> `@chrisnovakovic <https://github.com/chrisnovakovic>`_

--- a/crossplane/analyzer.py
+++ b/crossplane/analyzer.py
@@ -6,52 +6,69 @@ from .errors import (
 )
 
 # bit masks for different directive argument styles
-NGX_CONF_NOARGS = 0x00000001  # 0 args
-NGX_CONF_TAKE1  = 0x00000002  # 1 args
-NGX_CONF_TAKE2  = 0x00000004  # 2 args
-NGX_CONF_TAKE3  = 0x00000008  # 3 args
-NGX_CONF_TAKE4  = 0x00000010  # 4 args
-NGX_CONF_TAKE5  = 0x00000020  # 5 args
-NGX_CONF_TAKE6  = 0x00000040  # 6 args
-NGX_CONF_TAKE7  = 0x00000080  # 7 args
-NGX_CONF_BLOCK  = 0x00000100  # followed by block
-NGX_CONF_FLAG   = 0x00000200  # 'on' or 'off'
-NGX_CONF_ANY    = 0x00000400  # >=0 args
-NGX_CONF_1MORE  = 0x00000800  # >=1 args
-NGX_CONF_2MORE  = 0x00001000  # >=2 args
+NGX_ARGS_NOARGS = 0x00000001  # 0 args
+NGX_ARGS_TAKE1  = 0x00000002  # 1 args
+NGX_ARGS_TAKE2  = 0x00000004  # 2 args
+NGX_ARGS_TAKE3  = 0x00000008  # 3 args
+NGX_ARGS_TAKE4  = 0x00000010  # 4 args
+NGX_ARGS_TAKE5  = 0x00000020  # 5 args
+NGX_ARGS_TAKE6  = 0x00000040  # 6 args
+NGX_ARGS_TAKE7  = 0x00000080  # 7 args
+NGX_ARGS_BLOCK  = 0x00000100  # followed by block
+NGX_ARGS_FLAG   = 0x00000200  # 'on' or 'off'
+NGX_ARGS_ANY    = 0x00000400  # >=0 args
+NGX_ARGS_1MORE  = 0x00000800  # >=1 args
+NGX_ARGS_2MORE  = 0x00001000  # >=2 args
 
 # some helpful argument style aliases
-NGX_CONF_TAKE12   = (NGX_CONF_TAKE1 | NGX_CONF_TAKE2)
-NGX_CONF_TAKE13   = (NGX_CONF_TAKE1 | NGX_CONF_TAKE3)
-NGX_CONF_TAKE23   = (NGX_CONF_TAKE2 | NGX_CONF_TAKE3)
-NGX_CONF_TAKE34   = (NGX_CONF_TAKE3 | NGX_CONF_TAKE4)
-NGX_CONF_TAKE123  = (NGX_CONF_TAKE12 | NGX_CONF_TAKE3)
-NGX_CONF_TAKE1234 = (NGX_CONF_TAKE123 | NGX_CONF_TAKE4)
+NGX_ARGS_TAKE12   = (NGX_ARGS_TAKE1 | NGX_ARGS_TAKE2)
+NGX_ARGS_TAKE13   = (NGX_ARGS_TAKE1 | NGX_ARGS_TAKE3)
+NGX_ARGS_TAKE23   = (NGX_ARGS_TAKE2 | NGX_ARGS_TAKE3)
+NGX_ARGS_TAKE34   = (NGX_ARGS_TAKE3 | NGX_ARGS_TAKE4)
+NGX_ARGS_TAKE123  = (NGX_ARGS_TAKE12 | NGX_ARGS_TAKE3)
+NGX_ARGS_TAKE1234 = (NGX_ARGS_TAKE123 | NGX_ARGS_TAKE4)
 
 # bit masks for different directive locations
-NGX_DIRECT_CONF      = 0x00010000  # main file (not used)
-NGX_MAIN_CONF        = 0x00040000  # main context
-NGX_EVENT_CONF       = 0x00080000  # events
-NGX_MAIL_MAIN_CONF   = 0x00100000  # mail
-NGX_MAIL_SRV_CONF    = 0x00200000  # mail > server
-NGX_STREAM_MAIN_CONF = 0x00400000  # stream
-NGX_STREAM_SRV_CONF  = 0x00800000  # stream > server
-NGX_STREAM_UPS_CONF  = 0x01000000  # stream > upstream
-NGX_HTTP_MAIN_CONF   = 0x02000000  # http
-NGX_HTTP_SRV_CONF    = 0x04000000  # http > server
-NGX_HTTP_LOC_CONF    = 0x08000000  # http > location
-NGX_HTTP_UPS_CONF    = 0x10000000  # http > upstream
-NGX_HTTP_SIF_CONF    = 0x20000000  # http > server > if
-NGX_HTTP_LIF_CONF    = 0x40000000  # http > location > if
-NGX_HTTP_LMT_CONF    = 0x80000000  # http > location > limit_except
+NGX_DIRECT_CONF      = 0x00000001  # main file (not used)
+NGX_MAIN_CONF        = 0x00000002  # main context
+NGX_EVENT_CONF       = 0x00000004  # events
+NGX_MAIL_MAIN_CONF   = 0x00000008  # mail
+NGX_MAIL_SRV_CONF    = 0x00000010  # mail > server
+NGX_STREAM_MAIN_CONF = 0x00000020  # stream
+NGX_STREAM_MAP_CONF  = 0x00000040  # stream > map
+NGX_STREAM_SRV_CONF  = 0x00000080  # stream > server
+NGX_STREAM_UPS_CONF  = 0x00000100  # stream > upstream
+NGX_HTTP_MAIN_CONF   = 0x00000200  # http
+NGX_HTTP_MAP_CONF    = 0x00000400  # http > map
+NGX_HTTP_SRV_CONF    = 0x00000800  # http > server
+NGX_HTTP_LOC_CONF    = 0x00001000  # http > location
+NGX_HTTP_TYP_CONF    = 0x00002000  # http > types
+NGX_HTTP_UPS_CONF    = 0x00004000  # http > upstream
+NGX_HTTP_SIF_CONF    = 0x00008000  # http > server > if
+NGX_HTTP_STY_CONF    = 0x00010000  # http > server > types
+NGX_HTTP_LIF_CONF    = 0x00020000  # http > location > if
+NGX_HTTP_LMT_CONF    = 0x00040000  # http > location > limit_except
+NGX_HTTP_LTY_CONF    = 0x00080000  # http > location > types
 
 # helpful directive location alias describing "any" context
-# doesn't include NGX_HTTP_SIF_CONF, NGX_HTTP_LIF_CONF, or NGX_HTTP_LMT_CONF
+# doesn't include NGX_HTTP_SIF_CONF, NGX_HTTP_LIF_CONF, NGX_HTTP_LMT_CONF,
+# NGX_STREAM_MAP_CONF, NGX_HTTP_MAP_CONF, NGX_HTTP_TYP_CONF, NGX_HTTP_STY_CONF,
+# or NGX_HTTP_LTY_CONF
 NGX_ANY_CONF = (
     NGX_MAIN_CONF | NGX_EVENT_CONF | NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF |
     NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_STREAM_UPS_CONF |
     NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_UPS_CONF
 )
+
+# directive location alias describing any "map" context
+NGX_ANY_MAP = NGX_STREAM_MAP_CONF | NGX_HTTP_MAP_CONF
+
+# directive location alias describing any "types" context
+NGX_ANY_TYPES = NGX_HTTP_TYP_CONF | NGX_HTTP_STY_CONF | NGX_HTTP_LTY_CONF
+
+# directive location alias describing any context in which arbitrary directive
+# names are permitted
+NGX_ANY_DIRECTIVE = NGX_ANY_MAP | NGX_ANY_TYPES
 
 """
 DIRECTIVES
@@ -76,2020 +93,4273 @@ Definitions for directives that're only available for nginx+ were inferred
 """
 DIRECTIVES = {
     'absolute_redirect': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'accept_mutex': [
-        NGX_EVENT_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_EVENT_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'accept_mutex_delay': [
-        NGX_EVENT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_EVENT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'access_log': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_1MORE,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_HTTP_LMT_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'add_after_body': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'add_before_body': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'add_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE23
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE23,
+        },
     ],
     'add_trailer': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE23
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE23,
+        },
     ],
     'addition_types': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'aio': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'aio_write': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'alias': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'allow': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ancient_browser': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'ancient_browser_value': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'auth_basic': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'auth_basic_user_file': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'auth_http': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'auth_http_header': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'auth_http_pass_client_cert': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'auth_http_timeout': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'auth_request': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'auth_request_set': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'autoindex': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'autoindex_exact_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'autoindex_format': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'autoindex_localtime': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'break': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'charset': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'charset_map': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE2,
+        },
     ],
     'charset_types': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'chunked_transfer_encoding': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'client_body_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'client_body_in_file_only': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'client_body_in_single_buffer': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'client_body_temp_path': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1234
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1234,
+        },
     ],
     'client_body_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'client_header_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'client_header_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'client_max_body_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'connection_pool_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'create_full_put_path': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'daemon': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'dav_access': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE123
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE123,
+        },
     ],
     'dav_methods': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'debug_connection': [
-        NGX_EVENT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_EVENT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'debug_points': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+    ],
+    'default': [
+        {
+            'ctx': NGX_ANY_MAP,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'default_type': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'deny': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'directio': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'directio_alignment': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'disable_symlinks': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'empty_gif': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'env': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'error_log': [
-        NGX_MAIN_CONF | NGX_CONF_1MORE,
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_1MORE,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_MAIN_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'error_page': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_2MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
     ],
     'etag': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'events': [
-        NGX_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_NOARGS,
+        },
     ],
     'expires': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'fastcgi_bind': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'fastcgi_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_buffering': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_buffers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'fastcgi_busy_buffers_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_cache_background_update': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_cache_bypass': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'fastcgi_cache_key': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_cache_lock': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_cache_lock_age': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_cache_lock_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_cache_max_range_offset': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_cache_methods': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'fastcgi_cache_min_uses': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_cache_path': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_2MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
     ],
     'fastcgi_cache_revalidate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_cache_use_stale': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'fastcgi_cache_valid': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'fastcgi_catch_stderr': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_connect_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_force_ranges': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_hide_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_ignore_client_abort': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_ignore_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'fastcgi_index': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_intercept_errors': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_keep_conn': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_limit_rate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_max_temp_file_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_next_upstream': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'fastcgi_next_upstream_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_next_upstream_tries': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_no_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'fastcgi_param': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE23
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE23,
+        },
     ],
     'fastcgi_pass': [
-        NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_pass_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_pass_request_body': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_pass_request_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_read_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_request_buffering': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_send_lowat': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_send_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_socket_keepalive': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'fastcgi_split_path_info': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_store': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_store_access': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE123
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE123,
+        },
     ],
     'fastcgi_temp_file_write_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_temp_path': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1234
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1234,
+        },
     ],
     'flv': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'geo': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE12,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE12,
+        },
     ],
     'geoip_city': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE12,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'geoip_country': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE12,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'geoip_org': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE12,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'geoip_proxy': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'geoip_proxy_recursive': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'google_perftools_profiles': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_bind': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'grpc_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_connect_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_hide_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_ignore_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'grpc_intercept_errors': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'grpc_next_upstream': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'grpc_next_upstream_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_next_upstream_tries': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_pass': [
-        NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_pass_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_read_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_send_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_set_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'grpc_socket_keepalive': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'grpc_ssl_certificate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_ssl_certificate_key': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_ssl_ciphers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_ssl_crl': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_ssl_name': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_ssl_password_file': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_ssl_protocols': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'grpc_ssl_server_name': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'grpc_ssl_session_reuse': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'grpc_ssl_trusted_certificate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'grpc_ssl_verify': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'grpc_ssl_verify_depth': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'gunzip': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'gunzip_buffers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'gzip': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'gzip_buffers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'gzip_comp_level': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'gzip_disable': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'gzip_http_version': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'gzip_min_length': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'gzip_proxied': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'gzip_static': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'gzip_types': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'gzip_vary': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'hash': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_TAKE12,
-        NGX_STREAM_UPS_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_UPS_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+    ],
+    'hostnames': [
+        {
+            'ctx': NGX_ANY_MAP,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'http': [
-        NGX_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_NOARGS,
+        },
     ],
     'http2_body_preread_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'http2_chunk_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'http2_idle_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'http2_max_concurrent_pushes': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'http2_max_concurrent_streams': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'http2_max_field_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'http2_max_header_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'http2_max_requests': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'http2_push': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'http2_push_preload': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'http2_recv_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'http2_recv_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'if': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_BLOCK | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_1MORE,
+        },
     ],
     'if_modified_since': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ignore_invalid_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'image_filter': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_TAKE123
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE123,
+        },
     ],
     'image_filter_buffer': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'image_filter_interlace': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'image_filter_jpeg_quality': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'image_filter_sharpen': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'image_filter_transparency': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'image_filter_webp_quality': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'imap_auth': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'imap_capabilities': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'imap_client_buffer': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'include': [
-        NGX_ANY_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_ANY_CONF | NGX_ANY_MAP,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'index': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'internal': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'ip_hash': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'keepalive': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'keepalive_disable': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'keepalive_requests': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_HTTP_UPS_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'keepalive_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12,
-        NGX_HTTP_UPS_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'large_client_header_buffers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'least_conn': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_NOARGS,
-        NGX_STREAM_UPS_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
+        {
+            'ctx': NGX_STREAM_UPS_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'limit_conn': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'limit_conn_dry_run': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'limit_conn_log_level': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'limit_conn_status': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'limit_conn_zone': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE2,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'limit_except': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_BLOCK | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_1MORE,
+        },
     ],
     'limit_rate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'limit_rate_after': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'limit_req': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE123
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE123,
+        },
     ],
     'limit_req_dry_run': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'limit_req_log_level': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'limit_req_status': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'limit_req_zone': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE34
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE34,
+        },
     ],
     'lingering_close': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'lingering_time': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'lingering_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'listen': [
-        NGX_HTTP_SRV_CONF | NGX_CONF_1MORE,
-        NGX_MAIL_SRV_CONF | NGX_CONF_1MORE,
-        NGX_STREAM_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'load_module': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'location': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE12,
+        },
     ],
     'lock_file': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'log_format': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_2MORE,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_2MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
     ],
     'log_not_found': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'log_subrequest': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'mail': [
-        NGX_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_NOARGS,
+        },
     ],
     'map': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE2,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE2,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE2,
+        },
     ],
     'map_hash_bucket_size': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'map_hash_max_size': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'master_process': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'max_ranges': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'memcached_bind': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'memcached_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'memcached_connect_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'memcached_gzip_flag': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'memcached_next_upstream': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'memcached_next_upstream_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'memcached_next_upstream_tries': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'memcached_pass': [
-        NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'memcached_read_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'memcached_send_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'memcached_socket_keepalive': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'merge_slashes': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'min_delete_depth': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'mirror': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'mirror_request_body': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'modern_browser': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'modern_browser_value': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'mp4': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'mp4_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'mp4_max_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'msie_padding': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'msie_refresh': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'multi_accept': [
-        NGX_EVENT_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_EVENT_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'open_file_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'open_file_cache_errors': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'open_file_cache_min_uses': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'open_file_cache_valid': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'open_log_file_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1234,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1234
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1234,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1234,
+        },
     ],
     'output_buffers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'override_charset': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'pcre_jit': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'perl': [
-        NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'perl_modules': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'perl_require': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'perl_set': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'pid': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'pop3_auth': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'pop3_capabilities': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'port_in_redirect': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'postpone_output': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'preread_buffer_size': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'preread_timeout': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'protocol': [
-        NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_bind': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'proxy_buffer': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_buffering': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_buffers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'proxy_busy_buffers_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_cache_background_update': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_cache_bypass': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'proxy_cache_convert_head': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_cache_key': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_cache_lock': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_cache_lock_age': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_cache_lock_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_cache_max_range_offset': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_cache_methods': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'proxy_cache_min_uses': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_cache_path': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_2MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
     ],
     'proxy_cache_revalidate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_cache_use_stale': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'proxy_cache_valid': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'proxy_connect_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_cookie_domain': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'proxy_cookie_path': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'proxy_download_rate': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_force_ranges': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_headers_hash_bucket_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_headers_hash_max_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_hide_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_http_version': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_ignore_client_abort': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_ignore_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'proxy_intercept_errors': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_limit_rate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_max_temp_file_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_method': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_next_upstream': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_next_upstream_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_next_upstream_tries': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_no_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'proxy_pass': [
-        NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_HTTP_LMT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_pass_error_message': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_pass_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_pass_request_body': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_pass_request_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_protocol': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_protocol_timeout': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_read_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_redirect': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'proxy_request_buffering': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_requests': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_responses': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_send_lowat': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_send_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_set_body': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_set_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'proxy_socket_keepalive': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_ssl': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_ssl_certificate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_ssl_certificate_key': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_ssl_ciphers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_ssl_crl': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_ssl_name': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_ssl_password_file': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_ssl_protocols': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'proxy_ssl_server_name': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_ssl_session_reuse': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_ssl_trusted_certificate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_ssl_verify': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'proxy_ssl_verify_depth': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_store': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_store_access': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE123
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE123,
+        },
     ],
     'proxy_temp_file_write_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_temp_path': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1234
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1234,
+        },
     ],
     'proxy_timeout': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'proxy_upload_rate': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'random': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_NOARGS | NGX_CONF_TAKE12,
-        NGX_STREAM_UPS_CONF | NGX_CONF_NOARGS | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_NOARGS | NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_UPS_CONF,
+            'arg': NGX_ARGS_NOARGS | NGX_ARGS_TAKE12,
+        },
     ],
     'random_index': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'read_ahead': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'real_ip_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'real_ip_recursive': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'recursive_error_pages': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'referer_hash_bucket_size': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'referer_hash_max_size': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'request_pool_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'reset_timedout_connection': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'resolver': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE,
-        NGX_HTTP_UPS_CONF | NGX_CONF_1MORE,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_1MORE,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'resolver_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'return': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE12,
-        NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'rewrite': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE23
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE23,
+        },
     ],
     'rewrite_log': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'root': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'satisfy': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_bind': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'scgi_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_buffering': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_buffers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'scgi_busy_buffers_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_cache_background_update': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_cache_bypass': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'scgi_cache_key': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_cache_lock': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_cache_lock_age': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_cache_lock_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_cache_max_range_offset': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_cache_methods': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'scgi_cache_min_uses': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_cache_path': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_2MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
     ],
     'scgi_cache_revalidate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_cache_use_stale': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'scgi_cache_valid': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'scgi_connect_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_force_ranges': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_hide_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_ignore_client_abort': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_ignore_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'scgi_intercept_errors': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_limit_rate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_max_temp_file_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_next_upstream': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'scgi_next_upstream_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_next_upstream_tries': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_no_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'scgi_param': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE23
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE23,
+        },
     ],
     'scgi_pass': [
-        NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_pass_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_pass_request_body': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_pass_request_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_read_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_request_buffering': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_send_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_socket_keepalive': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'scgi_store': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_store_access': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE123
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE123,
+        },
     ],
     'scgi_temp_file_write_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'scgi_temp_path': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1234
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1234,
+        },
     ],
     'secure_link': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'secure_link_md5': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'secure_link_secret': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'send_lowat': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'send_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'sendfile': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'sendfile_max_chunk': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'server': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_NOARGS,
-        NGX_HTTP_UPS_CONF | NGX_CONF_1MORE,
-        NGX_MAIL_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_NOARGS,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_NOARGS,
-        NGX_STREAM_UPS_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_NOARGS,
+        },
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_NOARGS,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_NOARGS,
+        },
+        {
+            'ctx': NGX_STREAM_UPS_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'server_name': [
-        NGX_HTTP_SRV_CONF | NGX_CONF_1MORE,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'server_name_in_redirect': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'server_names_hash_bucket_size': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'server_names_hash_max_size': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'server_tokens': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'set': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'set_real_ip_from': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'slice': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'smtp_auth': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'smtp_capabilities': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'smtp_client_buffer': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'smtp_greeting_delay': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'source_charset': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'spdy_chunk_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'spdy_headers_comp': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'split_clients': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE2,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE2,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE2,
+        },
     ],
     'ssi': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'ssi_last_modified': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'ssi_min_file_chunk': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssi_silent_errors': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'ssi_types': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'ssi_value_length': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'ssl_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_certificate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_certificate_key': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_ciphers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_client_certificate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_crl': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_dhparam': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_early_data': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'ssl_ecdh_curve': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_engine': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_handshake_timeout': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_password_file': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_prefer_server_ciphers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_FLAG,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'ssl_preread': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'ssl_protocols': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_1MORE,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_1MORE,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'ssl_session_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE12,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE12,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'ssl_session_ticket_key': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_session_tickets': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_FLAG,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'ssl_session_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_stapling': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'ssl_stapling_file': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_stapling_responder': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_stapling_verify': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'ssl_trusted_certificate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_verify_client': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ssl_verify_depth': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'starttls': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'stream': [
-        NGX_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_NOARGS,
+        },
     ],
     'stub_status': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_NOARGS | NGX_ARGS_TAKE1,
+        },
     ],
     'sub_filter': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'sub_filter_last_modified': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'sub_filter_once': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'sub_filter_types': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'subrequest_output_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'tcp_nodelay': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG,
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'tcp_nopush': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'thread_pool': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE23
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE23,
+        },
     ],
     'timeout': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'timer_resolution': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'try_files': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_2MORE
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
     ],
     'types': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_BLOCK | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_NOARGS,
+        },
     ],
     'types_hash_bucket_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'types_hash_max_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'underscores_in_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uninitialized_variable_warn': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'upstream': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE1,
+        },
     ],
     'use': [
-        NGX_EVENT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_EVENT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'user': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'userid': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'userid_domain': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'userid_expires': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'userid_mark': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'userid_name': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'userid_p3p': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'userid_path': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'userid_service': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_bind': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'uwsgi_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_buffering': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_buffers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'uwsgi_busy_buffers_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_cache_background_update': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_cache_bypass': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'uwsgi_cache_key': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_cache_lock': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_cache_lock_age': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_cache_lock_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_cache_max_range_offset': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_cache_methods': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'uwsgi_cache_min_uses': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_cache_path': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_2MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
     ],
     'uwsgi_cache_revalidate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_cache_use_stale': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'uwsgi_cache_valid': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'uwsgi_connect_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_force_ranges': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_hide_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_ignore_client_abort': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_ignore_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'uwsgi_intercept_errors': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_limit_rate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_max_temp_file_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_modifier1': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_modifier2': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_next_upstream': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'uwsgi_next_upstream_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_next_upstream_tries': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_no_cache': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'uwsgi_param': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE23
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE23,
+        },
     ],
     'uwsgi_pass': [
-        NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_pass_header': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_pass_request_body': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_pass_request_headers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_read_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_request_buffering': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_send_timeout': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_socket_keepalive': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_ssl_certificate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_ssl_certificate_key': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_ssl_ciphers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_ssl_crl': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_ssl_name': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_ssl_password_file': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_ssl_protocols': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'uwsgi_ssl_server_name': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_ssl_session_reuse': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_ssl_trusted_certificate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_ssl_verify': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'uwsgi_ssl_verify_depth': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_store': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_store_access': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE123
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE123,
+        },
     ],
     'uwsgi_temp_file_write_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'uwsgi_temp_path': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1234
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1234,
+        },
     ],
     'valid_referers': [
-        NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'variables_hash_bucket_size': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'variables_hash_max_size': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+    ],
+    'volatile': [
+        {
+            'ctx': NGX_ANY_MAP,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'worker_aio_requests': [
-        NGX_EVENT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_EVENT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'worker_connections': [
-        NGX_EVENT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_EVENT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'worker_cpu_affinity': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'worker_priority': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'worker_processes': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'worker_rlimit_core': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'worker_rlimit_nofile': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'worker_shutdown_timeout': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'working_directory': [
-        NGX_MAIN_CONF | NGX_DIRECT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_MAIN_CONF | NGX_DIRECT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'xclient': [
-        NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_MAIL_MAIN_CONF | NGX_MAIL_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'xml_entities': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'xslt_last_modified': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'xslt_param': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'xslt_string_param': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'xslt_stylesheet': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'xslt_types': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'zone': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_TAKE12,
-        NGX_STREAM_UPS_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_UPS_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
 
     # nginx+ directives [definitions inferred from docs]
     'api': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_NOARGS | NGX_ARGS_TAKE1,
+        },
     ],
     'auth_jwt': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'auth_jwt_claim_set': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_2MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
     ],
     'auth_jwt_header_set': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_2MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
     ],
     'auth_jwt_key_file': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'auth_jwt_key_request': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'auth_jwt_leeway': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'f4f': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'f4f_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'fastcgi_cache_purge': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'health_check': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_ANY,
-        NGX_STREAM_SRV_CONF | NGX_CONF_ANY
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_ANY,
+        },
+        {
+            'ctx': NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_ANY,
+        },
     ],
     'health_check_timeout': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'hls': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'hls_buffers': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'hls_forward_args': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'hls_fragment': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'hls_mp4_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'hls_mp4_max_buffer_size': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'js_access': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'js_content': [
-        NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'js_filter': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'js_include': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'js_path': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'js_preread': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'js_set': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE2,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'keyval': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE3,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE3,
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE3,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE3,
+        },
     ],
     'keyval_zone': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_1MORE,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_1MORE,
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'least_time': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_TAKE12,
-        NGX_STREAM_UPS_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
+        {
+            'ctx': NGX_STREAM_UPS_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'limit_zone': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE3
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE3,
+        },
     ],
     'match': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE1,
-        NGX_STREAM_MAIN_CONF | NGX_CONF_BLOCK | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_MAIN_CONF,
+            'arg': NGX_ARGS_BLOCK | NGX_ARGS_TAKE1,
+        },
     ],
     'memcached_force_ranges': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'mp4_limit_rate': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'mp4_limit_rate_after': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'ntlm': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'proxy_cache_purge': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'queue': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'scgi_cache_purge': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'session_log': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'session_log_format': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_2MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_2MORE,
+        },
     ],
     'session_log_zone': [
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE23 | NGX_CONF_TAKE4 | NGX_CONF_TAKE5 | NGX_CONF_TAKE6
+        {
+            'ctx': NGX_HTTP_MAIN_CONF,
+            'arg': NGX_ARGS_TAKE23 | NGX_ARGS_TAKE4 | NGX_ARGS_TAKE5 | NGX_ARGS_TAKE6,
+        },
     ],
     'state': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_UPS_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_UPS_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'status': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'status_format': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'status_zone': [
-        NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1,
-        NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-        NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_HTTP_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+        {
+            'ctx': NGX_HTTP_LIF_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'sticky': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'sticky_cookie_insert': [
-        NGX_HTTP_UPS_CONF | NGX_CONF_TAKE1234
+        {
+            'ctx': NGX_HTTP_UPS_CONF,
+            'arg': NGX_ARGS_TAKE1234,
+        },
     ],
     'upstream_conf': [
-        NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'uwsgi_cache_purge': [
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'zone_sync': [
-        NGX_STREAM_SRV_CONF | NGX_CONF_NOARGS
+        {
+            'ctx': NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_NOARGS,
+        },
     ],
     'zone_sync_buffers': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE2
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE2,
+        },
     ],
     'zone_sync_connect_retry_interval': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_connect_timeout': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_interval': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_recv_buffer_size': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_server': [
-        NGX_STREAM_SRV_CONF | NGX_CONF_TAKE12
+        {
+            'ctx': NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE12,
+        },
     ],
     'zone_sync_ssl': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'zone_sync_ssl_certificate': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_ssl_certificate_key': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_ssl_ciphers': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_ssl_crl': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_ssl_name': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_ssl_password_file': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_ssl_protocols': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_1MORE
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_1MORE,
+        },
     ],
     'zone_sync_ssl_server_name': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'zone_sync_ssl_trusted_certificate': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_ssl_verify': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_FLAG
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_FLAG,
+        },
     ],
     'zone_sync_ssl_verify_depth': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
     ],
     'zone_sync_timeout': [
-        NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1
-    ]
+        {
+            'ctx': NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF,
+            'arg': NGX_ARGS_TAKE1,
+        },
+    ],
 }
 
 # map for getting bitmasks from certain context tuples
@@ -2099,15 +4369,20 @@ CONTEXTS = {
     ('mail',): NGX_MAIL_MAIN_CONF,
     ('mail', 'server'): NGX_MAIL_SRV_CONF,
     ('stream',): NGX_STREAM_MAIN_CONF,
+    ('stream', 'map'): NGX_STREAM_MAP_CONF,
     ('stream', 'server'): NGX_STREAM_SRV_CONF,
     ('stream', 'upstream'): NGX_STREAM_UPS_CONF,
     ('http',): NGX_HTTP_MAIN_CONF,
+    ('http', 'map'): NGX_HTTP_MAP_CONF,
     ('http', 'server'): NGX_HTTP_SRV_CONF,
     ('http', 'location'): NGX_HTTP_LOC_CONF,
+    ('http', 'types'): NGX_HTTP_TYP_CONF,
     ('http', 'upstream'): NGX_HTTP_UPS_CONF,
     ('http', 'server', 'if'): NGX_HTTP_SIF_CONF,
+    ('http', 'server', 'types'): NGX_HTTP_STY_CONF,
     ('http', 'location', 'if'): NGX_HTTP_LIF_CONF,
-    ('http', 'location', 'limit_except'): NGX_HTTP_LMT_CONF
+    ('http', 'location', 'limit_except'): NGX_HTTP_LMT_CONF,
+    ('http', 'location', 'types'): NGX_HTTP_LTY_CONF,
 }
 
 
@@ -2126,24 +4401,36 @@ def analyze(fname, stmt, term, ctx=(), strict=False, check_ctx=True,
     directive = stmt['directive']
     line = stmt['line']
 
-    # if strict and directive isn't recognized then throw error
-    if strict and directive not in DIRECTIVES:
+    ctx_any_directive = ctx in CONTEXTS and NGX_ANY_DIRECTIVE & CONTEXTS[ctx]
+
+    # if strict, context doesn't permit any directive and the directive isn't
+    # known, throw error
+    if strict and not ctx_any_directive and directive not in DIRECTIVES:
         reason = 'unknown directive "%s"' % directive
         raise NgxParserDirectiveUnknownError(reason, fname, line)
 
     # if we don't know where this directive is allowed and how
     # many arguments it can take then don't bother analyzing it
-    if ctx not in CONTEXTS or directive not in DIRECTIVES:
+    if ctx not in CONTEXTS or (not ctx_any_directive and directive not in DIRECTIVES):
         return
 
     args = stmt.get('args') or []
     n_args = len(args)
 
-    masks = DIRECTIVES[directive]
+    if directive in DIRECTIVES:
+        masks = DIRECTIVES[directive]
+    elif NGX_ANY_MAP & CONTEXTS[ctx]:
+        # map blocks can have arbitrary directives with 1 argument
+        masks = [{'ctx': NGX_ANY_MAP, 'arg': NGX_ARGS_1MORE}]
+    elif NGX_ANY_TYPES & CONTEXTS[ctx]:
+        # type blocks have arbitrary directives with 1 argument
+        masks = [{'ctx': NGX_ANY_TYPES, 'arg': NGX_ARGS_1MORE}]
+    else:
+        masks = []
 
     # if this directive can't be used in this context then throw an error
     if check_ctx:
-        masks = [mask for mask in masks if mask & CONTEXTS[ctx]]
+        masks = [mask for mask in masks if mask['ctx'] & CONTEXTS[ctx]]
         if not masks:
             reason = '"%s" directive is not allowed here' % directive
             raise NgxParserDirectiveContextError(reason, fname, line)
@@ -2156,24 +4443,24 @@ def analyze(fname, stmt, term, ctx=(), strict=False, check_ctx=True,
     # do this in reverse because we only throw errors at the end if no masks
     # are valid, and typically the first bit mask is what the parser expects
     for mask in reversed(masks):
-        # if the directive isn't a block but should be according to the mask
-        if mask & NGX_CONF_BLOCK and term != '{':
+        # if the directive isn't a block but should be according to the ctx mask
+        if mask['arg'] & NGX_ARGS_BLOCK and term != '{':
             reason = 'directive "%s" has no opening "{"'
             continue
 
-        # if the directive is a block but shouldn't be according to the mask
-        if not mask & NGX_CONF_BLOCK and term != ';':
+        # if the directive is a block but shouldn't be according to the arg mask
+        if not mask['arg'] & NGX_ARGS_BLOCK and term != ';':
             reason = 'directive "%s" is not terminated by ";"'
             continue
 
-        # use mask to check the directive's arguments
-        if ((mask >> n_args & 1 and n_args <= 7) or  # NOARGS to TAKE7
-            (mask & NGX_CONF_FLAG and n_args == 1 and valid_flag(args[0])) or
-            (mask & NGX_CONF_ANY and n_args >= 0) or
-            (mask & NGX_CONF_1MORE and n_args >= 1) or
-            (mask & NGX_CONF_2MORE and n_args >= 2)):
+        # use arg mask to check the directive's arguments
+        if ((mask['arg'] >> n_args & 1 and n_args <= 7) or  # NOARGS to TAKE7
+            (mask['arg'] & NGX_ARGS_FLAG and n_args == 1 and valid_flag(args[0])) or
+            (mask['arg'] & NGX_ARGS_ANY and n_args >= 0) or
+            (mask['arg'] & NGX_ARGS_1MORE and n_args >= 1) or
+            (mask['arg'] & NGX_ARGS_2MORE and n_args >= 2)):
             return
-        elif mask & NGX_CONF_FLAG and n_args == 1 and not valid_flag(args[0]):
+        elif mask['arg'] & NGX_ARGS_FLAG and n_args == 1 and not valid_flag(args[0]):
             reason = 'invalid value "%s" in "%%s" directive, it must be "on" or "off"' % args[0]
         else:
             reason = 'invalid number of arguments in "%s" directive'

--- a/tests/configs/map/map_values.conf
+++ b/tests/configs/map/map_values.conf
@@ -1,0 +1,2 @@
+*.example.com 2;
+\volatile 3;

--- a/tests/configs/map/nginx.conf
+++ b/tests/configs/map/nginx.conf
@@ -1,0 +1,9 @@
+http {
+    map $http_host $name {
+        hostnames;
+        volatile;
+        default 0;
+        example.com 1;
+        include map_values.conf;
+    }
+}

--- a/tests/configs/types/nginx.conf
+++ b/tests/configs/types/nginx.conf
@@ -1,0 +1,7 @@
+http {
+    types {
+        text/html  html;
+        image/gif  gif;
+        image/jpeg jpg jpeg;
+    }
+}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -226,6 +226,105 @@ def test_build_multiple_comments_on_one_line():
     assert built == '#comment1\nuser root; #comment2 #comment3'
 
 
+def test_build_map():
+    payload = [
+        {
+            'directive': 'http',
+            'line': 1,
+            'args': [],
+            'block': [
+                {
+                    'directive': 'map',
+                    'line': 2,
+                    'args': ['$http_host', '$name'],
+                    'block': [
+                        {
+                            'directive': 'hostnames',
+                            'line': 3,
+                            'args': []
+                        },
+                        {
+                            'directive': 'volatile',
+                            'line': 4,
+                            'args': []
+                        },
+                        {
+                            'directive': 'default',
+                            'line': 5,
+                            'args': ['0']
+                        },
+                        {
+                            'directive': 'example.com',
+                            'line': 6,
+                            'args': ['1']
+                        },
+                        {
+                            'directive': '\\volatile',
+                            'line': 7,
+                            'args': ['2']
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+    built = crossplane.build(payload, indent=4, tabs=False)
+    assert built == '\n'.join([
+        'http {',
+        '    map $http_host $name {',
+        '        hostnames;',
+        '        volatile;',
+        '        default 0;',
+        '        example.com 1;',
+        '        \\volatile 2;',
+        '    }',
+        '}'
+    ])
+
+
+def test_build_types():
+    payload = [
+        {
+            'directive': 'http',
+            'line': 1,
+            'args': [],
+            'block': [
+                {
+                    'directive': 'types',
+                    'line': 2,
+                    'args': [],
+                    'block': [
+                        {
+                            'directive': 'text/html',
+                            'line': 3,
+                            'args': ['html']
+                        },
+                        {
+                            'directive': 'image/gif',
+                            'line': 4,
+                            'args': ['gif']
+                        },
+                        {
+                            'directive': 'image/jpeg',
+                            'line': 5,
+                            'args': ['jpg', 'jpeg']
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+    built = crossplane.build(payload, indent=4, tabs=False)
+    assert built == '\n'.join([
+        'http {',
+        '    types {',
+        '        text/html html;',
+        '        image/gif gif;',
+        '        image/jpeg jpg jpeg;',
+        '    }',
+        '}'
+    ])
+
 
 def test_build_files_with_missing_status_and_errors(tmpdir):
     assert len(tmpdir.listdir()) == 0

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -975,3 +975,143 @@ def test_comments_between_args():
             }
         ]
     }
+
+
+def test_map_strict_ctx():
+    dirname = os.path.join(here, 'configs', 'map')
+    config = os.path.join(dirname, 'nginx.conf')
+    payload = crossplane.parse(
+        config,
+        strict=True,
+        check_ctx=True,
+        check_args=True,
+    )
+
+    # Check that errors aren't raised when parsing map blocks and strict and
+    # check_ctx are both enabled
+    assert payload == {
+        'status': 'ok',
+        'errors': [],
+        'config': [
+            {
+                'file': os.path.join(dirname, 'nginx.conf'),
+                'status': 'ok',
+                'errors': [],
+                'parsed': [
+                    {
+                        'directive': 'http',
+                        'line': 1,
+                        'args': [],
+                        'block': [
+                            {
+                                'directive': 'map',
+                                'line': 2,
+                                'args': ['$http_host', '$name'],
+                                'block': [
+                                    {
+                                        'directive': 'hostnames',
+                                        'line': 3,
+                                        'args': []
+                                    },
+                                    {
+                                        'directive': 'volatile',
+                                        'line': 4,
+                                        'args': []
+                                    },
+                                    {
+                                        'directive': 'default',
+                                        'line': 5,
+                                        'args': ['0']
+                                    },
+                                    {
+                                        'directive': 'example.com',
+                                        'line': 6,
+                                        'args': ['1']
+                                    },
+                                    {
+                                        'directive': 'include',
+                                        'line': 7,
+                                        'args': ['map_values.conf'],
+                                        'includes': [1]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                'file': os.path.join(dirname, 'map_values.conf'),
+                'status': 'ok',
+                'errors': [],
+                'parsed': [
+                    {
+                        'directive': '*.example.com',
+                        'line': 1,
+                        'args': ['2']
+                    },
+                    {
+                        'directive': '\\volatile',
+                        'line': 2,
+                        'args': ['3']
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def test_types_strict_ctx():
+    dirname = os.path.join(here, 'configs', 'types')
+    config = os.path.join(dirname, 'nginx.conf')
+    payload = crossplane.parse(
+        config,
+        strict=True,
+        check_ctx=True,
+        check_args=True,
+    )
+
+    # Check that errors aren't raised when parsing http types blocks and strict
+    # and check_ctx are both enabled
+    assert payload == {
+        'status': 'ok',
+        'errors': [],
+        'config': [
+            {
+                'file': os.path.join(dirname, 'nginx.conf'),
+                'status': 'ok',
+                'errors': [],
+                'parsed': [
+                    {
+                        'directive': 'http',
+                        'line': 1,
+                        'args': [],
+                        'block': [
+                            {
+                                'directive': 'types',
+                                'line': 2,
+                                'args': [],
+                                'block': [
+                                    {
+                                        'directive': 'text/html',
+                                        'line': 3,
+                                        'args': ['html']
+                                    },
+                                    {
+                                        'directive': 'image/gif',
+                                        'line': 4,
+                                        'args': ['gif']
+                                    },
+                                    {
+                                        'directive': 'image/jpeg',
+                                        'line': 5,
+                                        'args': ['jpg', 'jpeg']
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }


### PR DESCRIPTION
### Proposed changes

The `map` directive (from ngx_http_map_module and ngx_stream_map_module) and `types` directive (from ngx_http_core_module) are distinct from other directives, in that their child directives may be arbitrary strings that aren't known to Nginx. This causes crossplane to report unrecognised/misused directive errors when analysing them with `strict` or `check_ctx` enabled; it also means that no meaningful analysis can be performed when `check_args` is enabled because the arity of child directives is unknown.

Add support for `map`'s special directives (`default`, `hostnames`, and `volatile`) to the analyser. Recognise that arbitrary directive names inside a `map` or `types` block are valid and that they accept either one argument (if used in `map`) or one or more arguments (if used in `types`).

Fixes #101 and #103.

----

The restructuring of the bit masks in `analyzer.py` is necessary because there's no space left in the combined one on 32-bit architectures. Exploiting the fact that there isn't actually a need for the valid contexts and arguments information to be represented by the same bit mask, I've separated them into individual bit masks for each directive, restructured `DIRECTIVES` so each directive has a pair of bit masks (contexts + arguments) instead of an individual one, and modified `analyze` so it inspects the relevant one depending on the check being performed. This restructuring also creates space for 12 further new fields in the contexts bit mask and 19 further new fields in the arguments bit mask.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/crossplane/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork