### PR TITLE
Allow parsing non-Unicode nginx configurations

### DIFF
--- a/crossplane/lexer.py
+++ b/crossplane/lexer.py
@@ -145,7 +145,7 @@ def _balance_braces(tokens, filename=None):
 
 def lex(filename):
     """Generates tokens from an nginx config file"""
-    with io.open(filename, mode='r', encoding='utf-8') as f:
+    with io.open(filename, mode='r', encoding='utf-8', errors='replace') as f:
         it = _lex_file_object(f)
         it = _balance_braces(it, filename)
         for token, line, quoted in it:

--- a/tests/configs/non-unicode/nginx.conf
+++ b/tests/configs/non-unicode/nginx.conf
@@ -1,0 +1,8 @@
+http {
+    server {
+        location /city {
+            # Mölln
+            return 200 "Mölln\n";
+        }
+    }
+}

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -975,3 +975,60 @@ def test_comments_between_args():
             }
         ]
     }
+
+def test_non_unicode():
+    dirname = os.path.join(here, 'configs', 'non-unicode')
+    config = os.path.join(dirname, 'nginx.conf')
+
+    payload = crossplane.parse(config, comments=True)
+
+    assert payload == {
+        "errors": [],
+        "status": "ok",
+        "config": [
+            {
+                "status": "ok",
+                "errors": [],
+                "file": os.path.join(dirname, 'nginx.conf'),
+                "parsed": [
+                    {
+                        "directive": "http",
+                        "line": 1,
+                        "args": [],
+                        "block": [
+                            {
+                                "directive": "server",
+                                "line": 2,
+                                "args": [],
+                                "block": [
+                                    {
+                                        "directive": "location",
+                                        "line": 3,
+                                        "args": [
+                                            "/city"
+                                        ],
+                                        "block": [
+                                            {
+                                                "directive": "#",
+                                                "line": 4,
+                                                "args": [],
+                                                "comment": u" M\ufffdlln"
+                                            },
+                                            {
+                                                "directive": "return",
+                                                "line": 5,
+                                                "args": [
+                                                    "200",
+                                                    u"M\ufffdlln\\n"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }


### PR DESCRIPTION
### Proposed changes

This PR allows crossplane to parse non-Unicode nginx configurations without throwing UnicodeDecodeError. Such configurations are considered valid by nginx itself, so there is no reason for crossplane to give up on that.

The `replace` error handler was chosen as it allows to quickly determine whether there were any non-UTF symbols in the input by looking for the replacement sequence in parsed contents:
https://docs.python.org/3/library/codecs.html#error-handlers

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/crossplane/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
