### PR TITLE
add dockerfile to build crossplane tool as a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.8
+MAINTAINER Kylin Soong <kylinsoong.1214@gmail.com>
+
+RUN pip install crossplane
+
+VOLUME /etc/nginx
+
+ENTRYPOINT ["crossplane"]


### PR DESCRIPTION
I have a workshop with a customer used crossplane tool, but customer environment offline no internet access, I have build a docker image of crossplane which solved the crossplane installation issue, so If we build crossplane as a docker image, it may helpful.

Below link is how I use docker version crossplane.

https://hub.docker.com/r/cloudadc/crossplane