### PR TITLE
Pin GitHub Actions checkout and setup-python versions

### DIFF
--- a/.github/workflows/crossplane-ci.yml
+++ b/.github/workflows/crossplane-ci.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", pypy-3.6, pypy-3.7, pypy-3.8, pypy-3.9]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c #v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tox under Python ${{ matrix.python-version }}


### PR DESCRIPTION
Pin actions to their SHAs. No behaviour changes

- actions/checkout@v3 -> f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3
- actions/setup-python@v4 - > @7f4fc3e22c37d6ff65e88745f38bd3157c663f7c #v4